### PR TITLE
Configurable ram size

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ This fully self-contained extension will help you to quickly develop demos, intr
 - Frame Profiler: function-level + DMA profiling: during a debugging session, press the `Profile` button on the right of the debug toolbar, and 1 frame will be profiled. Press the rightmost button to profile 50 frames. Mark your WaitVBLs etc with calls to `debug_start_idle()` and `debug_stop_idle()` to show correct CPU usage under thumbnails.
 - Size Profiler: profile the size of your executable: right-click an ELF file in the Explorer, and select `Amiga: Profile File Size`
 - WinUAE debug overlay: see debug_* calls in template project's main.c
-- WinUAE: 
+- WinUAE:
   - <kbd>^</kbd> = single step, <kbd>Pause</kbd> = pause/resume <kbd>Page-up</kbd> = warp mode
   - all necessary options are already configured for Amiga 500, Kickstart 1.3 (for debugging), if you want to change some things (resolution, window size, etc.) just go into the `Configurations` tab, select `default`, and hit `Save`
 
 ## Supported Amiga Models
+
 - Possible values of `"config"` in `.vscode/launch.json`:
   - `"A500"`: KS 1.3, ECS Agnus, 0.5MB Chip + 0.5MB Slow; needs Kickstart 1.3 ROM in `"kickstart"`
   - `"A1200"`: 68020, 2MB Chip; needs Kickstart 3.1 ROM in `"kickstart"`
@@ -54,6 +55,10 @@ This fully self-contained extension will help you to quickly develop demos, intr
   - `"A1200-030"`: A1200 with Blizzard 1230-IV and 32MB board memory. Requires the absolute path to the Blizzard ROM in `"cpuboard"`.
   - `"A3000"`: A3000 (no profiler support); needs Kickstart 2.0 ROM in `"kickstart"`
   - `"A4000"`: 68030, 68882, 2MB Chip, 8MB FAST; needs Kickstart 3.1 ROM in `"kickstart"`
+- Also, you can override the memory configuration using following fields (values are case-insensitive):
+  - `"chipmem"` - allowed values: "256k", "512k", "1m", "1.5m" or "2m"
+  - `"fastmem"` - allowed values: "0", "64k", "128k", "256k", "512k", "1m", "2m", "4m", "8m"
+  - `"slowmem"` - allowed values: "0", "512k", "1m", "1.8m"
 
 ## Credits
 - Code by [Bartman/Abyss](https://github.com/BartmanAbyss)
@@ -81,7 +86,7 @@ Commodore Amiga Icon by [Icons8](https://iconscout.com/contributors/icons8).
 
 [The Player® 6.1A](https://www.pouet.net/prod.php?which=19922): Copyright © 1992-95 Jarno Paananen.
 
-P61.testmod - Module by Skylord/Sector 7 
+P61.testmod - Module by Skylord/Sector 7
 
 [depack_doynax.s](https://csdb.dk/release/?id=118678) - Lempel-Ziv decompressor by Johan "Doynax" Forslöf.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "amiga-debug",
-	"version": "1.1.0-preview27",
+	"version": "1.1.0-preview44",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/amigaDebug.ts
+++ b/src/amigaDebug.ts
@@ -25,6 +25,9 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	cpuboard?: string; // An absolute path to a CPU Board Expansion ROM
 	endcli?: boolean;
 	uaelog?: boolean;
+	chipmem?: string; // '256k', '512k', '1m', '1.5m' or '2m'
+	fastmem?: string; // '0', '64k', '128k', '256k', '512k', '1M', '2M', '4M', '8M'
+	slowmem?: string; // '0', '512k', '1M', '1.8M'
 }
 
 class ExtendedVariable {
@@ -252,6 +255,74 @@ export class AmigaDebugSession extends LoggingDebugSession {
 			config['debugging_trigger'] = path.basename(args.program) + ".exe";
 		else
 			config['debugging_trigger'] = ':' + path.basename(args.program) + ".exe";
+
+		// Optional override memory config
+		switch(args.chipmem?.toLowerCase()) {
+			case '256k':
+				config['chipmem_size'] = 0;
+				break;
+			case '512k':
+				config['chipmem_size'] = 1;
+				break;
+			case '1m':
+				config['chipmem_size'] = 2;
+				break;
+			case '1.5m':
+				config['chipmem_size'] = 3;
+				break;
+			case '2m':
+				config['chipmem_size'] = 4;
+				break;
+		}
+		switch(args.fastmem?.toLowerCase()) {
+			case '0k':
+			case '0m':
+			case '0':
+				config['fastmem_size'] = 0;
+				break;
+			case '64k':
+				config['fastmem_size_k'] = 64;
+				break;
+			case '128k':
+				config['fastmem_size_k'] = 128;
+				break;
+			case '256k':
+				config['fastmem_size_k'] = 256;
+				break;
+			case '512k':
+			case '0.5m':
+			case '.5m':
+				config['fastmem_size_k'] = 512;
+				break;
+			case '1m':
+				config['fastmem_size'] = 1;
+				break;
+			case '2m':
+				config['fastmem_size'] = 2;
+				break;
+			case '4m':
+				config['fastmem_size'] = 4;
+				break;
+			case '8m':
+				config['fastmem_size'] = 8;
+				break;
+		}
+		switch(args.slowmem?.toLowerCase()) {
+			case '0k':
+			case '0m':
+			case '0':
+				config['bogomem_size'] = 0;
+				break;
+			case '512k':
+				config['bogomem_size'] = 2;
+				break;
+			case '1m':
+				config['bogomem_size'] = 4;
+				break;
+			case '1.8m':
+				config['bogomem_size'] = 7;
+				break;
+		}
 
 		try {
 			fs.writeFileSync(defaultPath, stringifyCfg(config));


### PR DESCRIPTION
This allows to configure the memory size regardless of configuration default. This is helpful if e.g. targeting OCS with 2MB of CHIPmem (basically A500+ or A600 with expanded mem) without needing to use config with beefier CPU or introduce additional hard-coded configs.

I'd add description for fields when hovering in launch.json edit but dunno where it's stored. Tried to search for adjacent fields description but found nothing. :(

This time I've actually took the effort and tested it, so it should be good. ;)