### PR TITLE
Build binutils, gdb, gcc and elf2hunk for Linux

### DIFF
--- a/.github/workflows/.editorconfig
+++ b/.github/workflows/.editorconfig
@@ -1,0 +1,3 @@
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/binutils-gdb-gcc.yml
+++ b/.github/workflows/binutils-gdb-gcc.yml
@@ -5,8 +5,6 @@ on:
     paths:
       - "bin/gcc-barto.patch"
       - "ci/**"
-    paths-ignore:
-      - "ci/elf2hunk/**"
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/.github/workflows/binutils-gdb-gcc.yml
+++ b/.github/workflows/binutils-gdb-gcc.yml
@@ -1,4 +1,4 @@
-name: Binutils, GDB, and GCC
+name: binutils-gdb-gcc
 
 on:
   push:

--- a/.github/workflows/binutils-gdb-gcc.yml
+++ b/.github/workflows/binutils-gdb-gcc.yml
@@ -1,6 +1,9 @@
 name: Binutils, GDB, and GCC
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   linux:

--- a/.github/workflows/binutils-gdb-gcc.yml
+++ b/.github/workflows/binutils-gdb-gcc.yml
@@ -1,9 +1,9 @@
-name: CI
+name: Binutils, GDB, and GCC
 
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  binutils-gdb-gcc-linux:
+  linux:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -24,14 +24,3 @@ jobs:
         with:
           name: binutils-gdb-gcc-linux
           path: output/
-
-  elf2hunk-linux:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - run: ci/elf2hunk/clone.sh
-      - run: ci/elf2hunk/build.sh
-      - uses: actions/upload-artifact@v3
-        with:
-          name: elf2hunk-linux
-          path: elf2hunk/elf2hunk

--- a/.github/workflows/binutils-gdb-gcc.yml
+++ b/.github/workflows/binutils-gdb-gcc.yml
@@ -1,6 +1,12 @@
 name: Binutils, GDB, and GCC
 
 on:
+  push:
+    paths:
+      - "bin/gcc-barto.patch"
+      - "ci/**"
+    paths-ignore:
+      - "ci/elf2hunk/**"
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/.github/workflows/elf2hunk.yml
+++ b/.github/workflows/elf2hunk.yml
@@ -1,6 +1,9 @@
 name: elf2hunk
 
 on:
+  push:
+    paths:
+      - "ci/elf2hunk/**"
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/.github/workflows/elf2hunk.yml
+++ b/.github/workflows/elf2hunk.yml
@@ -1,0 +1,15 @@
+name: elf2hunk
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: ci/elf2hunk/clone.sh
+      - run: ci/elf2hunk/build.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: elf2hunk-linux
+          path: elf2hunk/elf2hunk

--- a/.github/workflows/elf2hunk.yml
+++ b/.github/workflows/elf2hunk.yml
@@ -1,6 +1,9 @@
 name: elf2hunk
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   linux:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  Windows:
-    runs-on: windows-2022
-
-    defaults:
-      run:
-        shell: wslbash.exe
-
+  build:
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           mkdir build-binutils-gdb
           cd build-binutils-gdb
-          LDFLAGS="-static -static-libgcc -static-libstdc++" ../binutils-gdb/configure --prefix=$GITHUB_WORKSPACE/output --target=m68k-amiga-elf --disable-werror -enable-static --disable-shared --disable-interprocess-agent --disable-libcc --host=x86_64
+          LDFLAGS="-static -static-libgcc -static-libstdc++" ../binutils-gdb/configure --prefix=$GITHUB_WORKSPACE/output --target=m68k-amiga-elf --disable-werror -enable-static --disable-shared --disable-interprocess-agent --disable-libcc
 
       - name: Build Binutils+GDB
         run: |
@@ -82,7 +82,6 @@ jobs:
             --disable-libvtv \
             --disable-nls \
             --disable-clocale \
-            --host=x86_64 \
             --enable-static
 
       - name: Skip GCC selftest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           rm -r output/include
           rm -r output/share
-          find output -name * | xargs strip
+          find output/bin -name "*" | xargs strip
 
       # Publish output
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ["github-actions"]
+    branches: ["github-actions-linux"]
   pull_request:
-    branches: ["github-actions"]
+    branches: ["github-actions-linux"]
   workflow_dispatch:
 
 jobs:
@@ -13,12 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # MinGW
+      # Install packages
 
-      - name: Install packages and set up MinGW
-        run: |
-          sudo apt install build-essential flex bison expect dejagnu texinfo mingw-w64
-          sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+      - name: Install packages
+        run: sudo apt install build-essential flex bison expect dejagnu texinfo
 
       # Binutils+GDB
 
@@ -34,7 +32,7 @@ jobs:
         run: |
           mkdir build-binutils-gdb
           cd build-binutils-gdb
-          LDFLAGS="-static -static-libgcc -static-libstdc++" ../binutils-gdb/configure --prefix=$GITHUB_WORKSPACE/output --target=m68k-amiga-elf --disable-werror -enable-static --disable-shared --disable-interprocess-agent --disable-libcc --host=x86_64-w64-mingw32
+          LDFLAGS="-static -static-libgcc -static-libstdc++" ../binutils-gdb/configure --prefix=$GITHUB_WORKSPACE/output --target=m68k-amiga-elf --disable-werror -enable-static --disable-shared --disable-interprocess-agent --disable-libcc --host=x86_64
 
       - name: Build Binutils+GDB
         run: |
@@ -84,20 +82,18 @@ jobs:
             --disable-libvtv \
             --disable-nls \
             --disable-clocale \
-            --host=x86_64-w64-mingw32 \
+            --host=x86_64 \
             --enable-static
 
-      - name: Build GCC
-        run: |
-          cd build-gcc-12.1.0
-          make all-gcc --jobs 4
-
-      - name: Build GCC again after changing Makefile
+      - name: Skip GCC selftest
         run: |
           cd build-gcc-12.1.0
           sed 's/selftest # srcextra/# selftest srcextra/' gcc/Makefile >gcc/Makefile.tmp
           mv gcc/Makefile.tmp gcc/Makefile
-          gcc/gcc-cross.exe -dumpspecs >gcc/specs
+
+      - name: Build GCC
+        run: |
+          cd build-gcc-12.1.0
           make all-gcc --jobs 4
 
       - name: Install GCC

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,103 +10,21 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    defaults:
-      run:
-        shell: /usr/bin/bash -e -u -x {0}
     steps:
       - uses: actions/checkout@v3
-
-      # Install packages
-
-      - name: Install packages
-        run: sudo apt install build-essential flex bison expect dejagnu texinfo
-
-      # Binutils+GDB
-
-      - name: Clone Binutils+GDB
-        run: git clone --depth=1 https://github.com/BartmanAbyss/binutils-gdb.git
-
-      - name: Download Binutils+GDB prerequisites
-        run: |
-          cd binutils-gdb
-          bash ./contrib/download_prerequisites
-
-      - name: Configure Binutils+GDB
-        run: |
-          mkdir build-binutils-gdb
-          cd build-binutils-gdb
-          LDFLAGS="-static -static-libgcc -static-libstdc++" ../binutils-gdb/configure --prefix=$GITHUB_WORKSPACE/output --target=m68k-amiga-elf --disable-werror -enable-static --disable-shared --disable-interprocess-agent --disable-libcc
-
-      - name: Build Binutils+GDB
-        run: |
-          cd build-binutils-gdb
-          make --jobs 4
-
-      - name: Install Binutils+GDB
-        run: |
-          cd build-binutils-gdb
-          make install
-
-      # GCC
-
-      - name: Download GCC
-        run: |
-          wget https://ftp.gwdg.de/pub/misc/gcc/releases/gcc-12.1.0/gcc-12.1.0.tar.xz
-          tar -xf gcc-12.1.0.tar.xz
-
-      - name: Patch GCC
-        run: |
-          cd gcc-12.1.0
-          patch -p1 < ../bin/gcc-barto.patch
-
-      - name: Download GCC prerequisites
-        run: |
-          cd gcc-12.1.0
-          bash ./contrib/download_prerequisites
-
-      - name: Configure GCC
-        run: |
-          mkdir -p build-gcc-12.1.0
-          cd build-gcc-12.1.0
-          LDFLAGS="-static -static-libgcc -static-libstdc++" ../gcc-12.1.0/configure \
-            --target=m68k-amiga-elf \
-            --disable-nls \
-            --enable-languages=c,c++ \
-            --enable-lto \
-            --prefix=$GITHUB_WORKSPACE/output \
-            --disable-libssp \
-            --disable-gcov \
-            --disable-multilib \
-            --disable-threads \
-            --with-cpu=68000 \
-            --disable-libsanitizer \
-            --disable-libada \
-            --disable-libgomp \
-            --disable-libvtv \
-            --disable-nls \
-            --disable-clocale \
-            --enable-static
-
-      - name: Build GCC
-        run: |
-          cd build-gcc-12.1.0
-          make all-gcc --jobs 4
-
-      - name: Install GCC
-        run: |
-          cd build-gcc-12.1.0
-          make install-gcc
-
-      # Cleaning up unnecessary files and stripping EXE files of debug information to reduce size
-
-      - name: Cleaning up
-        run: |
-          rm -r output/include
-          rm -r output/share
-          find output/bin -type f -and -not -name m68k-amiga-elf-gdb-add-index | xargs strip
-
-      # Publish output
-
+      - run: ci/install-packages-linux.sh
+      - run: ci/binutils-gdb/clone.sh
+      - run: ci/binutils-gdb/download-prerequisites.sh
+      - run: ci/binutils-gdb/configure-linux.sh
+      - run: ci/binutils-gdb/build-linux.sh
+      - run: ci/binutils-gdb/install.sh
+      - run: ci/gcc/download.sh
+      - run: ci/gcc/patch.sh
+      - run: ci/gcc/download-prerequisites.sh
+      - run: ci/gcc/configure-linux.sh
+      - run: ci/gcc/build-linux.sh
+      - run: ci/gcc/install.sh
+      - run: ci/clean-up-linux.sh
       - uses: actions/upload-artifact@v3
         with:
           name: output

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,11 +98,11 @@ jobs:
           sed 's/selftest # srcextra/# selftest srcextra/' gcc/Makefile >gcc/Makefile.tmp
           mv gcc/Makefile.tmp gcc/Makefile
           gcc/gcc-cross.exe -dumpspecs >gcc/specs
+          make all-gcc --jobs 4
 
       - name: Install GCC
         run: |
           cd build-gcc-12.1.0
-          make all-gcc --jobs 4
           make install-gcc
 
       # Cleaning up unnecessary files and stripping EXE files of debug information to reduce size

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-22.04
+  Windows:
+    runs-on: windows-2022
+
+    defaults:
+      run:
+        shell: wslbash.exe
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  binutils-gdb-gcc-linux:
+  binutils-gdb-linux:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -13,6 +13,17 @@ jobs:
       - run: ci/binutils-gdb/configure-linux.sh
       - run: ci/binutils-gdb/build-linux.sh
       - run: ci/binutils-gdb/install.sh
+      - run: ci/clean-up-linux.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: binutils-gdb-linux
+          path: output/
+
+  gcc-linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: ci/install-packages-linux.sh
       - run: ci/gcc/download.sh
       - run: ci/gcc/patch.sh
       - run: ci/gcc/download-prerequisites.sh
@@ -22,7 +33,7 @@ jobs:
       - run: ci/clean-up-linux.sh
       - uses: actions/upload-artifact@v3
         with:
-          name: binutils-gdb-gcc-linux
+          name: gcc-linux
           path: output/
 
   elf2hunk-linux:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,12 +84,6 @@ jobs:
             --disable-clocale \
             --enable-static
 
-      - name: Skip GCC selftest
-        run: |
-          cd build-gcc-12.1.0
-          sed 's/selftest # srcextra/# selftest srcextra/' gcc/Makefile >gcc/Makefile.tmp
-          mv gcc/Makefile.tmp gcc/Makefile
-
       - name: Build GCC
         run: |
           cd build-gcc-12.1.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,6 @@ jobs:
         run: |
           rm -r output/include
           rm -r output/share
-          find output/bin -name "*" | xargs strip
 
       # Publish output
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,6 +103,7 @@ jobs:
         run: |
           rm -r output/include
           rm -r output/share
+          find output/bin -type f -and -not -name m68k-amiga-elf-gdb-add-index | xargs strip
 
       # Publish output
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  binutils-gdb-linux:
+  binutils-gdb-gcc-linux:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -13,17 +13,6 @@ jobs:
       - run: ci/binutils-gdb/configure-linux.sh
       - run: ci/binutils-gdb/build-linux.sh
       - run: ci/binutils-gdb/install.sh
-      - run: ci/clean-up-linux.sh
-      - uses: actions/upload-artifact@v3
-        with:
-          name: binutils-gdb-linux
-          path: output/
-
-  gcc-linux:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - run: ci/install-packages-linux.sh
       - run: ci/gcc/download.sh
       - run: ci/gcc/patch.sh
       - run: ci/gcc/download-prerequisites.sh
@@ -33,7 +22,7 @@ jobs:
       - run: ci/clean-up-linux.sh
       - uses: actions/upload-artifact@v3
         with:
-          name: gcc-linux
+          name: binutils-gdb-gcc-linux
           path: output/
 
   elf2hunk-linux:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,14 @@ jobs:
         with:
           name: binutils-gdb-gcc-linux
           path: output/
+
+  elf2hunk-linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: ci/elf2hunk/clone.sh
+      - run: ci/elf2hunk/build.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: elf2hunk-linux
+          path: elf2hunk/elf2hunk

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: /usr/bin/bash -e -u -x {0}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: ["github-actions"]
+  pull_request:
+    branches: ["github-actions"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      # MinGW
+
+      - name: Install packages and set up MinGW
+        run: |
+          sudo apt install build-essential flex bison expect dejagnu texinfo mingw-w64
+          sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+
+      # Binutils+GDB
+
+      - name: Clone Binutils+GDB
+        run: git clone --depth=1 https://github.com/BartmanAbyss/binutils-gdb.git
+
+      - name: Download Binutils+GDB prerequisites
+        run: |
+          cd binutils-gdb
+          bash ./contrib/download_prerequisites
+
+      - name: Configure Binutils+GDB
+        run: |
+          mkdir build-binutils-gdb
+          cd build-binutils-gdb
+          LDFLAGS="-static -static-libgcc -static-libstdc++" ../binutils-gdb/configure --prefix=$GITHUB_WORKSPACE/output --target=m68k-amiga-elf --disable-werror -enable-static --disable-shared --disable-interprocess-agent --disable-libcc --host=x86_64-w64-mingw32
+
+      - name: Build Binutils+GDB
+        run: |
+          cd build-binutils-gdb
+          make --jobs 4
+
+      - name: Install Binutils+GDB
+        run: |
+          cd build-binutils-gdb
+          make install
+
+      # Cleaning up unnecessary files and stripping EXE files of debug information to reduce size
+
+      - name: Cleaning up
+        run: |
+          rm -r output/include
+          rm -r output/share
+          find output -name *.exe | xargs strip
+
+      # Publish output
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: output
+          path: output/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,5 +27,5 @@ jobs:
       - run: ci/clean-up-linux.sh
       - uses: actions/upload-artifact@v3
         with:
-          name: output
+          name: linux
           path: output/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  build:
+  binutils-gdb-gcc-linux:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -22,5 +22,5 @@ jobs:
       - run: ci/clean-up-linux.sh
       - uses: actions/upload-artifact@v3
         with:
-          name: linux
+          name: binutils-gdb-gcc-linux
           path: output/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           rm -r output/include
           rm -r output/share
-          find output -name *.exe | xargs strip
+          find output -name * | xargs strip
 
       # Publish output
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,65 @@ jobs:
           cd build-binutils-gdb
           make install
 
+      # GCC
+
+      - name: Download GCC
+        run: |
+          wget https://ftp.gwdg.de/pub/misc/gcc/releases/gcc-12.1.0/gcc-12.1.0.tar.xz
+          tar -xf gcc-12.1.0.tar.xz
+
+      - name: Patch GCC
+        run: |
+          cd gcc-12.1.0
+          patch -p1 < ../bin/gcc-barto.patch
+
+      - name: Download GCC prerequisites
+        run: |
+          cd gcc-12.1.0
+          bash ./contrib/download_prerequisites
+
+      - name: Configure GCC
+        run: |
+          mkdir -p build-gcc-12.1.0
+          cd build-gcc-12.1.0
+          LDFLAGS="-static -static-libgcc -static-libstdc++" ../gcc-12.1.0/configure \
+            --target=m68k-amiga-elf \
+            --disable-nls \
+            --enable-languages=c,c++ \
+            --enable-lto \
+            --prefix=$GITHUB_WORKSPACE/output \
+            --disable-libssp \
+            --disable-gcov \
+            --disable-multilib \
+            --disable-threads \
+            --with-cpu=68000 \
+            --disable-libsanitizer \
+            --disable-libada \
+            --disable-libgomp \
+            --disable-libvtv \
+            --disable-nls \
+            --disable-clocale \
+            --host=x86_64-w64-mingw32 \
+            --enable-static
+
+      - name: Build GCC
+        run: |
+          cd build-gcc-12.1.0
+          make all-gcc --jobs 4
+
+      - name: Build GCC again after changing Makefile
+        run: |
+          cd build-gcc-12.1.0
+          sed 's/selftest # srcextra/# selftest srcextra/' gcc/Makefile >gcc/Makefile.tmp
+          mv gcc/Makefile.tmp gcc/Makefile
+          gcc/gcc-cross.exe -dumpspecs >gcc/specs
+
+      - name: Install GCC
+        run: |
+          cd build-gcc-12.1.0
+          make all-gcc --jobs 4
+          make install-gcc
+
       # Cleaning up unnecessary files and stripping EXE files of debug information to reduce size
 
       - name: Cleaning up

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches: ["github-actions-linux"]
-  pull_request:
-    branches: ["github-actions-linux"]
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Binutils, GDB, and GCC](https://github.com/BartmanAbyss/vscode-amiga-debug/actions/workflows/binutils-gdb-gcc.yml/badge.svg?branch=master&event=schedule)](https://github.com/BartmanAbyss/vscode-amiga-debug/actions/workflows/binutils-gdb-gcc.yml)
+[![elf2hunk](https://github.com/BartmanAbyss/vscode-amiga-debug/actions/workflows/elf2hunk.yml/badge.svg?branch=master&event=schedule)](https://github.com/BartmanAbyss/vscode-amiga-debug/actions/workflows/elf2hunk.yml)
+
 # _amiga-debug_ Visual Studio Code Extension (Windows only)
 
 **One-stop Visual Studio Code Extention to compile, debug and profile Amiga C/C++ programs compiled by the bundled gcc 12.1 with the bundled WinUAE.**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Binutils, GDB, and GCC](https://github.com/BartmanAbyss/vscode-amiga-debug/actions/workflows/binutils-gdb-gcc.yml/badge.svg?branch=master&event=schedule)](https://github.com/BartmanAbyss/vscode-amiga-debug/actions/workflows/binutils-gdb-gcc.yml)
-[![elf2hunk](https://github.com/BartmanAbyss/vscode-amiga-debug/actions/workflows/elf2hunk.yml/badge.svg?branch=master&event=schedule)](https://github.com/BartmanAbyss/vscode-amiga-debug/actions/workflows/elf2hunk.yml)
+[![Binutils, GDB, and GCC](https://github.com/BartmanAbyss/vscode-amiga-debug/actions/workflows/binutils-gdb-gcc.yml/badge.svg?branch=master)](https://github.com/BartmanAbyss/vscode-amiga-debug/actions/workflows/binutils-gdb-gcc.yml)
+[![elf2hunk](https://github.com/BartmanAbyss/vscode-amiga-debug/actions/workflows/elf2hunk.yml/badge.svg?branch=master)](https://github.com/BartmanAbyss/vscode-amiga-debug/actions/workflows/elf2hunk.yml)
 
 # _amiga-debug_ Visual Studio Code Extension (Windows only)
 

--- a/ci/binutils-gdb/build-linux.sh
+++ b/ci/binutils-gdb/build-linux.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+cd build-binutils-gdb
+make --jobs 4

--- a/ci/binutils-gdb/clone.sh
+++ b/ci/binutils-gdb/clone.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+git clone --depth=1 https://github.com/BartmanAbyss/binutils-gdb.git

--- a/ci/binutils-gdb/configure-linux.sh
+++ b/ci/binutils-gdb/configure-linux.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+mkdir build-binutils-gdb
+cd build-binutils-gdb
+LDFLAGS="-static -static-libgcc -static-libstdc++" ../binutils-gdb/configure \
+    --prefix=$GITHUB_WORKSPACE/output \
+    --target=m68k-amiga-elf \
+    --disable-werror \
+    -enable-static \
+    --disable-shared \
+    --disable-interprocess-agent \
+    --disable-libcc

--- a/ci/binutils-gdb/configure-linux.sh
+++ b/ci/binutils-gdb/configure-linux.sh
@@ -6,10 +6,10 @@ set -x
 mkdir build-binutils-gdb
 cd build-binutils-gdb
 LDFLAGS="-static -static-libgcc -static-libstdc++" ../binutils-gdb/configure \
-    --prefix=$GITHUB_WORKSPACE/output \
-    --target=m68k-amiga-elf \
-    --disable-werror \
-    -enable-static \
-    --disable-shared \
     --disable-interprocess-agent \
-    --disable-libcc
+    --disable-libcc \
+    --disable-shared \
+    --disable-werror \
+    --enable-static \
+    --prefix=$GITHUB_WORKSPACE/output \
+    --target=m68k-amiga-elf

--- a/ci/binutils-gdb/download-prerequisites.sh
+++ b/ci/binutils-gdb/download-prerequisites.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+cd binutils-gdb
+bash ./contrib/download_prerequisites

--- a/ci/binutils-gdb/install.sh
+++ b/ci/binutils-gdb/install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+cd build-binutils-gdb
+make install

--- a/ci/clean-up-linux.sh
+++ b/ci/clean-up-linux.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+cd output
+rm -r include
+rm -r share
+find bin -type f -and -not -name m68k-amiga-elf-gdb-add-index | xargs strip

--- a/ci/elf2hunk/build.sh
+++ b/ci/elf2hunk/build.sh
@@ -4,4 +4,4 @@ IFS=$'\n\t'
 set -x
 
 cd elf2hunk
-gcc -o elf2hunk -O2 cp-demangle.c elf2hunk.c
+make

--- a/ci/elf2hunk/build.sh
+++ b/ci/elf2hunk/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+cd elf2hunk
+gcc -o elf2hunk -O2 cp-demangle.c elf2hunk.c

--- a/ci/elf2hunk/clone.sh
+++ b/ci/elf2hunk/clone.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+git clone --depth=1 https://github.com/BartmanAbyss/elf2hunk.git

--- a/ci/gcc/build-linux.sh
+++ b/ci/gcc/build-linux.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+cd build-gcc-12.1.0
+make all-gcc --jobs 4

--- a/ci/gcc/build-linux.sh
+++ b/ci/gcc/build-linux.sh
@@ -3,5 +3,5 @@ set -euo pipefail
 IFS=$'\n\t'
 set -x
 
-cd build-gcc-12.1.0
+cd build-gcc
 make all-gcc --jobs 4

--- a/ci/gcc/configure-linux.sh
+++ b/ci/gcc/configure-linux.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+mkdir -p build-gcc-12.1.0
+cd build-gcc-12.1.0
+LDFLAGS="-static -static-libgcc -static-libstdc++" ../gcc-12.1.0/configure \
+    --target=m68k-amiga-elf \
+    --disable-nls \
+    --enable-languages=c,c++ \
+    --enable-lto \
+    --prefix=$GITHUB_WORKSPACE/output \
+    --disable-libssp \
+    --disable-gcov \
+    --disable-multilib \
+    --disable-threads \
+    --with-cpu=68000 \
+    --disable-libsanitizer \
+    --disable-libada \
+    --disable-libgomp \
+    --disable-libvtv \
+    --disable-nls \
+    --disable-clocale \
+    --enable-static

--- a/ci/gcc/configure-linux.sh
+++ b/ci/gcc/configure-linux.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 IFS=$'\n\t'
 set -x
 
-mkdir -p build-gcc-12.1.0
-cd build-gcc-12.1.0
-LDFLAGS="-static -static-libgcc -static-libstdc++" ../gcc-12.1.0/configure \
+mkdir -p build-gcc
+cd build-gcc
+LDFLAGS="-static -static-libgcc -static-libstdc++" ../gcc/configure \
     --target=m68k-amiga-elf \
     --disable-nls \
     --enable-languages=c,c++ \

--- a/ci/gcc/configure-linux.sh
+++ b/ci/gcc/configure-linux.sh
@@ -6,20 +6,19 @@ set -x
 mkdir -p build-gcc
 cd build-gcc
 LDFLAGS="-static -static-libgcc -static-libstdc++" ../gcc/configure \
-    --target=m68k-amiga-elf \
-    --disable-nls \
-    --enable-languages=c,c++ \
-    --enable-lto \
-    --prefix=$GITHUB_WORKSPACE/output \
-    --disable-libssp \
+    --disable-clocale \
     --disable-gcov \
-    --disable-multilib \
-    --disable-threads \
-    --with-cpu=68000 \
-    --disable-libsanitizer \
     --disable-libada \
     --disable-libgomp \
+    --disable-libsanitizer \
+    --disable-libssp \
     --disable-libvtv \
+    --disable-multilib \
     --disable-nls \
-    --disable-clocale \
-    --enable-static
+    --disable-threads \
+    --enable-languages=c,c++ \
+    --enable-lto \
+    --enable-static \
+    --prefix=$GITHUB_WORKSPACE/output \
+    --target=m68k-amiga-elf \
+    --with-cpu=68000

--- a/ci/gcc/download-prerequisites.sh
+++ b/ci/gcc/download-prerequisites.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+cd gcc-12.1.0
+bash ./contrib/download_prerequisites

--- a/ci/gcc/download-prerequisites.sh
+++ b/ci/gcc/download-prerequisites.sh
@@ -3,5 +3,5 @@ set -euo pipefail
 IFS=$'\n\t'
 set -x
 
-cd gcc-12.1.0
+cd gcc
 bash ./contrib/download_prerequisites

--- a/ci/gcc/download.sh
+++ b/ci/gcc/download.sh
@@ -5,3 +5,4 @@ set -x
 
 wget https://ftp.gwdg.de/pub/misc/gcc/releases/gcc-12.1.0/gcc-12.1.0.tar.xz
 tar -xf gcc-12.1.0.tar.xz
+mv gcc-12.1.0 gcc

--- a/ci/gcc/download.sh
+++ b/ci/gcc/download.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+wget https://ftp.gwdg.de/pub/misc/gcc/releases/gcc-12.1.0/gcc-12.1.0.tar.xz
+tar -xf gcc-12.1.0.tar.xz

--- a/ci/gcc/install.sh
+++ b/ci/gcc/install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+cd build-gcc-12.1.0
+make install-gcc

--- a/ci/gcc/install.sh
+++ b/ci/gcc/install.sh
@@ -3,5 +3,5 @@ set -euo pipefail
 IFS=$'\n\t'
 set -x
 
-cd build-gcc-12.1.0
+cd build-gcc
 make install-gcc

--- a/ci/gcc/patch.sh
+++ b/ci/gcc/patch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+cd gcc-12.1.0
+patch -p1 < ../bin/gcc-barto.patch

--- a/ci/gcc/patch.sh
+++ b/ci/gcc/patch.sh
@@ -3,5 +3,5 @@ set -euo pipefail
 IFS=$'\n\t'
 set -x
 
-cd gcc-12.1.0
+cd gcc
 patch -p1 < ../bin/gcc-barto.patch

--- a/ci/install-packages-linux.sh
+++ b/ci/install-packages-linux.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+sudo apt install build-essential flex bison expect dejagnu texinfo


### PR DESCRIPTION
# Context

Currently the extension only works on Windows. As a long term goal, it would be great if we could have some of the functionality on other OSes like Linux and Mac.

This PR is a baby step in that direction, with minimal impact on folks who currently use the extension on Windows.

# Scope

In scope:

* Build the required tools for Linux
* Provide them for download
* Ensure the build stays working

Out of scope:

* Building tools for Windows or Mac (Linux was easier)
* Building Amiga executables (the built toolchain has not been tested)
* Debugging

# Issues to resolve

General structure: Are we happy with GitHub Actions?

Are the triggers OK?

Should the build steps be inline in the workflow file rather than delegated to helper scripts?

Should the helper scripts be runnable outside of GitHub Actions?

Should the README be updated to point to the workflow as an example of how to port to other systems?