### PR TITLE
Strip all files

### DIFF
--- a/ci/clean-up-linux.sh
+++ b/ci/clean-up-linux.sh
@@ -6,4 +6,4 @@ set -x
 cd output
 rm -r include
 rm -r share
-find bin -type f -and -not -name m68k-amiga-elf-gdb-add-index | xargs strip
+find . -type f -exec strip {} \;


### PR DESCRIPTION
find -exec can be used instead of piping to xargs, to ignore errors