### PR TITLE
Strip during install rather than during cleanup

### DIFF
--- a/ci/binutils-gdb/install.sh
+++ b/ci/binutils-gdb/install.sh
@@ -4,4 +4,4 @@ IFS=$'\n\t'
 set -x
 
 cd build-binutils-gdb
-make install
+make install-strip

--- a/ci/clean-up-linux.sh
+++ b/ci/clean-up-linux.sh
@@ -6,4 +6,3 @@ set -x
 cd output
 rm -r include
 rm -r share
-find . -type f -exec strip {} \;

--- a/ci/gcc/install.sh
+++ b/ci/gcc/install.sh
@@ -4,4 +4,4 @@ IFS=$'\n\t'
 set -x
 
 cd build-gcc
-make install-gcc
+make install-strip-gcc


### PR DESCRIPTION
I haven't updated the Windows instructions in the README as I haven't verified that it works on Windows.

It looks fine for Linux though. I downloaded the artifacts from a previous run without these changes, and a run with these changes, and compared them.

All the executables seem to be the same size, so stripped.

There are a couple of .a files, which now do not get stripped. I think this is the correct behaviour, and we were stripping these unnecessarily.

If you have time, would you be able to try the changes on Windows?