### PR TITLE
Configurable program name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ template/obj8mingw
 template/obj
 template/*.elf
 template/a.mingw.*
+!template/out/
+template/out/*
+!template/out/DELETE.ME
 template/.vscode/settings.json
 src/test/suite/data/private
 src/test/suite/data/output

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	"activationEvents": [
 		"onDebug",
 		"onCommand:amiga.bin-path",
+		"onCommand:amiga.program",		
 		"onCommand:amiga.initProject",
 		"onCommand:amiga.terminal",
 		"onCommand:amiga.profileSize",
@@ -371,7 +372,19 @@
 					"when": "debugType == amiga"
 				}
 			]
-		}
+		},
+		"configuration": [
+			{
+				"title": "Amiga C/C++ Compile, Debug & Profile",
+				"properties": {
+					"amiga.program": {
+						"type": "string",
+						"default": "out\\a.mingw",
+						"description": "Program to launch when not defined in launch.json (relative to the workspace folder)."
+					}
+				}
+			}			
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "webpack --mode=production",

--- a/src/amigaDebug.ts
+++ b/src/amigaDebug.ts
@@ -25,7 +25,7 @@ const DEBUG = false;
 
 interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	config?: string; // A500 (default), A1200, etc.
-	program: string; // An absolute path to the "program" to debug. basename only; .elf and .exe will be added respectively to find ELF and Amiga-HUNK file
+	program?: string; // An absolute path to the "program" to debug. basename only; .elf and .exe will be added respectively to find ELF and Amiga-HUNK file
 	kickstart?: string; // An absolute path to a Kickstart ROM; if not specified, AROS will be used
 	cpuboard?: string; // An absolute path to a CPU Board Expansion ROM
 	endcli?: boolean;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import * as Net from 'net';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import * as utils from './utils';
 import { CppToolsApi, Version, CustomConfigurationProvider, getCppToolsApi, SourceFileConfigurationItem, WorkspaceBrowseConfiguration, SourceFileConfiguration } from 'vscode-cpptools';
 import { CancellationToken } from 'vscode-jsonrpc';
 
@@ -140,6 +141,7 @@ class AmigaDebugExtension {
 			vscode.commands.registerCommand('amiga.bin-path', () => path.join(this.extensionPath, 'bin')),
 			vscode.commands.registerCommand('amiga.initProject', this.initProject.bind(this)),
 			vscode.commands.registerCommand('amiga.terminal', this.openTerminal.bind(this)),
+			vscode.commands.registerCommand('amiga.program', () => utils.getProgramName()),
 
 			// window
 			vscode.window.registerTreeDataProvider('amiga.registers', this.registerProvider),
@@ -583,7 +585,10 @@ class AmigaDebugConfigurationProvider implements vscode.DebugConfigurationProvid
 				return undefined;	// abort launch
 			});
 		}
-
+		if(!config.program) { // Resolve the program folder.
+			const workspaceFolder  = vscode.workspace.workspaceFolders[0].uri.fsPath;
+			config.program = path.join(workspaceFolder, utils.getProgramName().toString());
+		}
 		if(!config.program) {
 			return vscode.window.showInformationMessage("Cannot find a program to debug").then((_) => {
 				return undefined;	// abort launch

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import * as vscode from 'vscode';
+
 export function hexFormat(value: number, padding = 8, includePrefix = true): string {
 	let base = value.toString(16);
 	while (base.length < padding) { base = '0' + base; }
@@ -33,3 +35,5 @@ export function extractBits(value: number, offset: number, width: number) {
 	const bvalue = ((value & mask) >>> offset) >>> 0;
 	return bvalue;
 }
+
+export const getProgramName = () : string => vscode.workspace.getConfiguration('amiga').get('program')?.toString() ?? "a.mingw";

--- a/template/.vscode/launch.json
+++ b/template/.vscode/launch.json
@@ -7,7 +7,7 @@
             "preLaunchTask": "compile",
             "name": "AROS",
             "config": "A500",
-            "program": "${workspaceFolder}/a.mingw",
+//          "program": "${workspaceFolder}/a.mingw", // Infer from settings.
             "internalConsoleOptions": "openOnSessionStart"
         },
         {
@@ -16,7 +16,7 @@
             "preLaunchTask": "compile",
             "name": "Amiga 500",
             "config": "A500",
-            "program": "${workspaceFolder}/a.mingw",
+//          "program": "${workspaceFolder}/a.mingw", // Infer from settings.
             "kickstart": "c:/amiga/KICK13.rom",
             "internalConsoleOptions": "openOnSessionStart"
         },
@@ -26,7 +26,7 @@
             "preLaunchTask": "compile",
             "name": "Amiga 1200",
             "config": "A1200",
-            "program": "${workspaceFolder}/a.mingw",
+//          "program": "${workspaceFolder}/a.mingw", // Infer from settings.
             "kickstart": "c:/amiga/KICK31.rom",
             "internalConsoleOptions": "openOnSessionStart"
         },
@@ -36,7 +36,7 @@
             "preLaunchTask": "compile",
             "name": "Amiga 4000",
             "config": "A4000",
-            "program": "${workspaceFolder}/a.mingw",
+//          "program": "${workspaceFolder}/a.mingw", // Infer from settings.
             "kickstart": "c:/amiga/KICK31.rom",
             "internalConsoleOptions": "openOnSessionStart"
         }        

--- a/template/.vscode/tasks.json
+++ b/template/.vscode/tasks.json
@@ -9,6 +9,8 @@
             "command": "${command:amiga.bin-path}\\gnumake.exe",
             "args": [
                 "-j4",
+                "extensionPath=${command:amiga.bin-path}", 
+                "program=${workspaceFolder}\\${command:amiga.program}" 
             ],
             "options": {
                 "cwd": "${workspaceRoot}",

--- a/template/Makefile
+++ b/template/Makefile
@@ -7,19 +7,20 @@ SHELL = cmd.exe
 forward-to-backward = $(subst /,\,$1)
 
 subdirs := $(wildcard */)
+code_subdirs:= $(filter-out out/,$(subdirs))
 VPATH = $(subdirs)
-cpp_sources := $(wildcard *.cpp) $(wildcard $(addsuffix *.cpp,$(subdirs)))
+cpp_sources := $(wildcard *.cpp) $(wildcard $(addsuffix *.cpp,$(code_subdirs)))
 cpp_objects := $(addprefix obj/,$(patsubst %.cpp,%.o,$(notdir $(cpp_sources))))
-c_sources := $(wildcard *.c) $(wildcard $(addsuffix *.c,$(subdirs)))
+c_sources := $(wildcard *.c) $(wildcard $(addsuffix *.c,$(code_subdirs)))
 c_objects := $(addprefix obj/,$(patsubst %.c,%.o,$(notdir $(c_sources))))
-s_sources := support/gcc8_a_support.s support/depacker_doynax.s
+s_sources := $(wildcard *.s) $(wildcard $(addsuffix *.s, $(code_subdirs)))
 s_objects := $(addprefix obj/,$(patsubst %.s,%.o,$(notdir $(s_sources))))
 objects := $(cpp_objects) $(c_objects) $(s_objects)
 
 # https://stackoverflow.com/questions/4036191/sources-from-subdirectories-in-makefile/4038459
 # http://www.microhowto.info/howto/automatically_generate_makefile_dependencies.html
 
-OUT = a.mingw
+OUT = $(program)
 CC = m68k-amiga-elf-gcc
 
 CCFLAGS = -g -MP -MMD -m68000 -Ofast -nostdlib -Wextra -Wno-unused-function -Wno-volatile-register-var -fomit-frame-pointer -fno-tree-loop-distribution -flto -fwhole-program -fno-exceptions


### PR DESCRIPTION
This pull request allows the user to configure the name and path (relative to the workspace) of the program via configuration setting "amiga.program".

Default is "out/a.mingw". The "out" folder is included in the template because the compiler needs it but does not create it.

Now all .s files are assembled, but the ones in the "out" folder.