### PR TITLE
New targets (Debug, Release, Final, Shrinkler).

### DIFF
--- a/package.json
+++ b/package.json
@@ -456,6 +456,11 @@
 						"type": "string",
 						"default": "c:/amiga/KICK31.rom",
 						"description": "Path to the Kickstart ROM for A4000 models."
+					},
+					"amiga.shrinkler.options": {
+						"type": "string",
+						"default": "-h -f dff180 -9 -t Decrunching...",
+						"description": "Additional arguments when packing Shrinkler targets."
 					}
 				}
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -151,6 +151,7 @@ class AmigaDebugExtension {
 			vscode.commands.registerCommand('amiga.externalResources.colorReducer', () => MinimalBrowser.launchUrl('http://deadliners.net/ColorReducer', 'Color Reducer')),
 			vscode.commands.registerCommand('amiga.externalResources.bltconCheatSheet', () => MinimalBrowser.launchUrl('http://deadliners.net/BLTCONCheatSheet', 'BLTCON Cheat Sheet')),
 			vscode.commands.registerCommand('amiga.externalResources.amigaHRM', () => MinimalBrowser.launchUrl('http://amigadev.elowar.com/read/ADCD_2.1/Hardware_Manual_guide/node0000.html', 'Amiga Hardware Reference Manual')),
+			vscode.commands.registerCommand('amiga.programFolder', () => path.dirname(vscode.workspace.getConfiguration('amiga').get('program')?.toString().replace('\\', '/'))),
 
 			// window
 			vscode.window.registerTreeDataProvider('amiga.registers', this.registerProvider),

--- a/template/.vscode/launch.json
+++ b/template/.vscode/launch.json
@@ -7,7 +7,7 @@
             "preLaunchTask": "compile",
             "name": "AROS",
             "config": "A500",
-            "program": "${workspaceFolder}/${config:amiga.program}",
+            "program": "${workspaceFolder}/${config:amiga.program}-rel",
             "internalConsoleOptions": "openOnSessionStart"
         },
         {
@@ -16,7 +16,7 @@
             "preLaunchTask": "compile",
             "name": "Amiga 500",
             "config": "A500",
-            "program": "${workspaceFolder}/${config:amiga.program}",
+            "program": "${workspaceFolder}/${config:amiga.program}-rel",
             "kickstart": "${config:amiga.rom-paths.A500}",
             "internalConsoleOptions": "openOnSessionStart"
         },
@@ -26,7 +26,7 @@
             "preLaunchTask": "compile",
             "name": "Amiga 1200",
             "config": "A1200",
-            "program": "${workspaceFolder}/${config:amiga.program}",
+            "program": "${workspaceFolder}/${config:amiga.program}-rel",
             "kickstart": "${config:amiga.rom-paths.A1200}",
             "internalConsoleOptions": "openOnSessionStart"
         },
@@ -35,6 +35,123 @@
             "request": "launch",
             "preLaunchTask": "compile",
             "name": "Amiga 4000",
+            "config": "A4000",
+            "program": "${workspaceFolder}/${config:amiga.program}-rel",
+            "kickstart": "${config:amiga.rom-paths.A4000}",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "type": "amiga",
+            "request": "launch",
+            "preLaunchTask": "compile-debug",
+            "name": "Debug - AROS",
+            "config": "A500",
+            "program": "${workspaceFolder}/${config:amiga.program}-dbg",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "type": "amiga",
+            "request": "launch",
+            "preLaunchTask": "compile-debug",
+            "name": "Debug - Amiga 500",
+            "config": "A500",
+            "program": "${workspaceFolder}/${config:amiga.program}-dbg",
+            "kickstart": "${config:amiga.rom-paths.A500}",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "type": "amiga",
+            "request": "launch",
+            "preLaunchTask": "compile-debug",
+            "name": "Debug - Amiga 1200",
+            "config": "A1200",
+            "program": "${workspaceFolder}/${config:amiga.program}-dbg",
+            "kickstart": "${config:amiga.rom-paths.A1200}",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "type": "amiga",
+            "request": "launch",
+            "preLaunchTask": "compile-debug",
+            "name": "Debug - Amiga 4000",
+            "config": "A4000",
+            "program": "${workspaceFolder}/${config:amiga.program}-dbg",
+            "kickstart": "${config:amiga.rom-paths.A4000}",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "type": "amiga",
+            "request": "launch",
+            "preLaunchTask": "compile-final",
+            "name": "Final - AROS",
+            "config": "A500",
+            "program": "${workspaceFolder}/${config:amiga.program}",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "type": "amiga",
+            "request": "launch",
+            "preLaunchTask": "compile-final",
+            "name": "Final - Amiga 500",
+            "config": "A500",
+            "program": "${workspaceFolder}/${config:amiga.program}",
+            "kickstart": "${config:amiga.rom-paths.A500}",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "type": "amiga",
+            "request": "launch",
+            "preLaunchTask": "compile-final",
+            "name": "Final - Amiga 1200",
+            "config": "A1200",
+            "program": "${workspaceFolder}/${config:amiga.program}",
+            "kickstart": "${config:amiga.rom-paths.A1200}",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "type": "amiga",
+            "request": "launch",
+            "preLaunchTask": "compile-final",
+            "name": "Final - Amiga 4000",
+            "config": "A4000",
+            "program": "${workspaceFolder}/${config:amiga.program}",
+            "kickstart": "${config:amiga.rom-paths.A4000}",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "type": "amiga",
+            "request": "launch",
+            "preLaunchTask": "compile-shrinkled",
+            "name": "Shrinkled - AROS",
+            "config": "A500",
+            "program": "${workspaceFolder}/${config:amiga.program}",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "type": "amiga",
+            "request": "launch",
+            "preLaunchTask": "compile-shrinkled",
+            "name": "Shrinkled - Amiga 500",
+            "config": "A500",
+            "program": "${workspaceFolder}/${config:amiga.program}",
+            "kickstart": "${config:amiga.rom-paths.A500}",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "type": "amiga",
+            "request": "launch",
+            "preLaunchTask": "compile-shrinkled",
+            "name": "Shrinkled - Amiga 1200",
+            "config": "A1200",
+            "program": "${workspaceFolder}/${config:amiga.program}",
+            "kickstart": "${config:amiga.rom-paths.A1200}",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "type": "amiga",
+            "request": "launch",
+            "preLaunchTask": "compile-shrinkled",
+            "name": "Shrinkled - Amiga 4000",
             "config": "A4000",
             "program": "${workspaceFolder}/${config:amiga.program}",
             "kickstart": "${config:amiga.rom-paths.A4000}",

--- a/template/.vscode/tasks.json
+++ b/template/.vscode/tasks.json
@@ -85,8 +85,8 @@
                 "-j4",
                 "program=${workspaceFolder}\\${config:amiga.program}",
                 "targetName=Final",
-                "ccExtraOptions=-Ofast -DNDEBUG",
-                "vasmExtraOptions=-DNDEBUG",
+                "ccExtraOptions=-gdwarf-3 -Ofast -DNDEBUG",
+                "vasmExtraOptions=-dwarf=3 -DNDEBUG",
                 "programFolder=${command:amiga.programFolder}"
             ],
             "options": {

--- a/template/.vscode/tasks.json
+++ b/template/.vscode/tasks.json
@@ -9,7 +9,11 @@
             "command": "${command:amiga.bin-path}\\gnumake.exe",
             "args": [
                 "-j4",
-                "program=${config:amiga.program}"
+                "program=${workspaceFolder}\\${config:amiga.program}-rel",
+                "targetName=Release",
+                "ccExtraOptions=-gdwarf-3 -Ofast -DDEBUG",
+                "vasmExtraOptions=-dwarf=3 -DDEBUG",
+                "programFolder=${command:amiga.programFolder}"
             ],
             "options": {
                 "cwd": "${workspaceRoot}",
@@ -35,6 +39,105 @@
                 "kind": "build",
                 "isDefault": true
             }
-        }
+        },
+        {
+            "label": "compile-debug",
+            "type": "shell",
+            "command": "${command:amiga.bin-path}\\gnumake.exe",
+            "args": [
+                "-j4",
+                "program=${workspaceFolder}\\${config:amiga.program}-dbg",
+                "targetName=Debug",
+                "ccExtraOptions=-gdwarf-3 -DDEBUG",
+                "vasmExtraOptions=-dwarf=3 -DDEBUG",
+                "programFolder=${command:amiga.programFolder}"
+            ],
+            "options": {
+                "cwd": "${workspaceRoot}",
+                "env": {
+                    "PATH": "${env:PATH};${command:amiga.bin-path}\\opt\\bin;${command:amiga.bin-path}"
+                }
+            },
+            "problemMatcher": [
+                {
+                    "base": "$gcc",
+                    "fileLocation": "absolute"
+                }
+            ],
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": true
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "compile-final",
+            "type": "shell",
+            "command": "${command:amiga.bin-path}\\gnumake.exe",
+            "args": [
+                "-j4",
+                "program=${workspaceFolder}\\${config:amiga.program}",
+                "targetName=Final",
+                "ccExtraOptions=-Ofast -DNDEBUG",
+                "vasmExtraOptions=-DNDEBUG",
+                "programFolder=${command:amiga.programFolder}"
+            ],
+            "options": {
+                "cwd": "${workspaceRoot}",
+                "env": {
+                    "PATH": "${env:PATH};${command:amiga.bin-path}\\opt\\bin;${command:amiga.bin-path}"
+                }
+            },
+            "problemMatcher": [
+                {
+                    "base": "$gcc",
+                    "fileLocation": "absolute"
+                }
+            ],
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": true
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "label"  : "compile-shrinkled",
+            "type"   : "shell",
+            "command": "${workspaceRoot}/mkfinal.bat",
+            "args"   : [ "${workspaceFolder}\\${config:amiga.program}.exe", "${command:amiga.bin-path}", "${config:amiga.shrinkler.options}" ],
+            "options": 
+            {
+                "cwd": "${workspaceRoot}",
+                "env": {
+                    "PATH": "${command:amiga.bin-path}\\opt\\bin;${command:amiga.bin-path}"
+                }
+            },
+            "problemMatcher": [ { "base": "$gcc", "fileLocation": "absolute" } ],
+            "presentation"  : 
+            {
+                "echo"      : true,
+                "reveal"    : "silent",
+                "focus"     : false,
+                "panel"     : "shared",
+                "showReuseMessage": false,
+                "clear"     : true
+            },
+            "group": { "kind": "build", "isDefault": false },
+            "dependsOn": [ "compile-final" ]
+        }        
     ]
 }

--- a/template/Makefile
+++ b/template/Makefile
@@ -3,35 +3,41 @@
 # to generate assembler source with LTO, add to LDFLAGS: -save-temps=cwd
 
 SHELL = cmd.exe
+programFolder = out
+targetName = Final
 
 forward-to-backward = $(subst /,\,$1)
 
 subdirs := $(wildcard */)
+code_subdirs:= $(filter-out resources/, $(filter-out $(programFolder)/,$(subdirs)))
 VPATH = $(subdirs)
-cpp_sources := $(wildcard *.cpp) $(wildcard $(addsuffix *.cpp,$(subdirs)))
-cpp_objects := $(addprefix obj/,$(patsubst %.cpp,%.o,$(notdir $(cpp_sources))))
-c_sources := $(wildcard *.c) $(wildcard $(addsuffix *.c,$(subdirs)))
-c_objects := $(addprefix obj/,$(patsubst %.c,%.o,$(notdir $(c_sources))))
-s_sources := support/gcc8_a_support.s support/depacker_doynax.s
-s_objects := $(addprefix obj/,$(patsubst %.s,%.o,$(notdir $(s_sources))))
+cpp_sources := $(wildcard *.cpp) $(wildcard $(addsuffix *.cpp,$(code_subdirs)))
+cpp_objects := $(addprefix obj/$(targetName)/,$(patsubst %.cpp,%.o,$(notdir $(cpp_sources))))
+c_sources := $(wildcard *.c) $(wildcard $(addsuffix *.c,$(code_subdirs)))
+c_objects := $(addprefix obj/$(targetName)/,$(patsubst %.c,%.o,$(notdir $(c_sources))))
+s_sources := $(wildcard *.s) $(wildcard $(addsuffix *.s, $(code_subdirs)))
+s_objects := $(addprefix obj/$(targetName)/,$(patsubst %.s,%.o,$(notdir $(s_sources))))
 vasm_sources := $(wildcard *.asm) $(wildcard $(addsuffix *.asm, $(subdirs)))
-vasm_objects := $(addprefix obj/, $(patsubst %.asm,%.o,$(notdir $(vasm_sources))))
+vasm_objects := $(addprefix obj/$(targetName)/, $(patsubst %.asm,%.o,$(notdir $(vasm_sources))))
 objects := $(cpp_objects) $(c_objects) $(s_objects) $(vasm_objects)
 
 # https://stackoverflow.com/questions/4036191/sources-from-subdirectories-in-makefile/4038459
 # http://www.microhowto.info/howto/automatically_generate_makefile_dependencies.html
 
-program = out/a
+program = $(programFolder)/a
+ccExtraOptions = -Ofast -DNDEBUG
+vasmExtraOptions = -DNDEBUG
+
 OUT = $(call forward-to-backward,$(program))
 CC = m68k-amiga-elf-gcc
 VASM = vasmm68k_mot_win32.exe
 SDKDIR = $(call forward-to-backward,$(abspath $(dir $(shell where $(CC)))..\m68k-amiga-elf\sys-include))
 
-CCFLAGS = -g -MP -MMD -m68000 -Ofast -nostdlib -Wextra -Wno-unused-function -Wno-volatile-register-var -fomit-frame-pointer -fno-tree-loop-distribution -flto -fwhole-program -fno-exceptions
+CCFLAGS = $(ccExtraOptions) -MP -MMD -m68000 -nostdlib -Wextra -Wno-unused-function -Wno-volatile-register-var -fomit-frame-pointer -fno-tree-loop-distribution -flto -fwhole-program -fno-exceptions
 CPPFLAGS= $(CCFLAGS) -fno-rtti -fcoroutines -fno-use-cxa-atexit
 ASFLAGS = -Wa,-g,--register-prefix-optional,-I$(SDKDIR),-D
 LDFLAGS = -Wl,--emit-relocs,-Ttext=0,-Map=$(OUT).map
-VASMFLAGS = -m68000 -Felf -opt-fconst -nowarn=62 -dwarf=3 -quiet -x -I. -I$(SDKDIR) 
+VASMFLAGS = $(vasmExtraOptions) -m68000 -Felf -opt-fconst -nowarn=62 -quiet -x -I. -I$(SDKDIR) 
 
 all: $(OUT).exe
 
@@ -46,26 +52,26 @@ $(OUT).elf: $(objects)
 
 clean:
 	$(info Cleaning...)
-	@del /q obj $(OUT).* 2>nul || rmdir obj 2>nul || ver>nul
+	@del /q obj/$(targetName)/ $(OUT).* 2>nul || rmdir obj/$(targetName)/ 2>nul || ver>nul
 
 -include $(objects:.o=.d)
 
-$(cpp_objects) : obj/%.o : %.cpp
+$(cpp_objects) : obj/$(targetName)/%.o : %.cpp
 	@if not exist "$(call forward-to-backward,$(dir $@))" mkdir $(call forward-to-backward,$(dir $@))
 	$(info Compiling $<)
 	@$(CC) $(CPPFLAGS) -c -o $@ $(CURDIR)/$<
 
-$(c_objects) : obj/%.o : %.c
+$(c_objects) : obj/$(targetName)/%.o : %.c
 	@if not exist "$(call forward-to-backward,$(dir $@))" mkdir $(call forward-to-backward,$(dir $@))
 	$(info Compiling $<)
 	@$(CC) $(CCFLAGS) -c -o $@ $(CURDIR)/$<
 
-$(s_objects): obj/%.o : %.s
+$(s_objects): obj/$(targetName)/%.o : %.s
 	@if not exist "$(call forward-to-backward,$(dir $@))" mkdir $(call forward-to-backward,$(dir $@))
 	$(info Assembling $<)
 	@$(CC) $(CCFLAGS) $(ASFLAGS) -c -o $@ $(CURDIR)/$<
 
-$(vasm_objects): obj/%.o : %.asm
+$(vasm_objects): obj/$(targetName)/%.o : %.asm
 	@if not exist "$(call forward-to-backward,$(dir $@))" mkdir $(call forward-to-backward,$(dir $@))
 	$(info Assembling $<)
 	@$(VASM) $(VASMFLAGS) -o $@ $(CURDIR)/$<

--- a/template/mkfinal.bat
+++ b/template/mkfinal.bat
@@ -1,0 +1,18 @@
+@echo off
+
+rem @file   mkfinal.bat
+rem @author David Cañadas Mazo
+
+pushd
+
+set "PROGRAMNAME=%~1"
+set "PROGRAMNAME=%PROGRAMNAME:/=\%"
+set "LOCALPROGRAMNAME=%~nx1"
+set "LOCALPROGRAMNAME=%LOCALPROGRAMNAME:/=\%"
+
+cd "%~dp0"
+"%~2\Shrinkler.exe" %~3 "%PROGRAMNAME%" "%PROGRAMNAME%.slow.shrinkled"
+del "%PROGRAMNAME%"
+ren "%PROGRAMNAME%.slow.shrinkled" "%LOCALPROGRAMNAME%"
+popd
+goto:eof


### PR DESCRIPTION
This PR provides replaces built-in targets `AROS`, `A500`, `A1200` and `A4000` with more specific targets:

**Release**
* Default target used when compiling with Ctrl+Shift+B.
* Defines the `DEBUG` macro.
* Enables optimizations which may render some code not debuggable.
* Additional GCC/GAS options: `-gdwarf-3 -Ofast -DDEBUG`.
* Additional VASM options: `-dwarf=3 -DDEBUG`.

**Debug**
* Defines the `DEBUG` macro.
* Disables all optimizations. Code is debuggable at the cost of losing some performance.
* Additional GCC/GAS options: `-gdwarf-3 -DDEBUG`.
* Additional VASM options: `-dwarf=3 -DDEBUG`.

**Final**
* Makefile targets this by default.
* Same as final but enables macro `NDEBUG` instead of `DEBUG` to provide some sort of stripping at the source code level.
* Additional GCC/GAS options: `-gdwarf-3 -Ofast -DNDEBUG`.
* Additional VASM options: `-dwarf=3 -DNDEBUG`.

**Shrinkled**
* Same as **Final** but shrinkles the executable using the new option `amiga.shrinkler.options` in the Settings page. 
* The executable launched in the emulator is the shrinkled one (which is renamed to the name of the program). 
* Symbol stripping still has to be done using the `-s` parameter when calling `elf2hunk`.
* Shrinkling is done by an external file `mkfinal.bat`.

Potential improvements:
* Splitting **Shrinkled** into two targets, one for profiling (which includes DWARF information) and one for publishing (not including DWARF information + calling `elf2hunk` with parameter `-s`).

Related to: https://github.com/BartmanAbyss/vscode-amiga-debug/issues/52

PS: This is my last Pull Request for now :) (It's the only actual difference between the extension and my fork). Maybe is too specific and out of the scope of the template, however it is worth the try!