### PR TITLE
Populate compiler path setting in template

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -289,7 +289,7 @@ class AmigaDebugExtension {
 			void vscode.window.showErrorMessage('Unable to show disassembly.');
 		}
 	}
-	private initProject() {
+	private async initProject() {
 		const copyRecursiveSync = (src: string, dest: string) => {
 			const exists = fs.existsSync(src);
 			const stats = exists && fs.statSync(src);
@@ -317,6 +317,13 @@ class AmigaDebugExtension {
 				return;
 			}
 			copyRecursiveSync(source, dest);
+
+			// Replace compiler path placeholder:
+			const settingsPath = path.join(dest, '.vscode', 'settings.json');
+			const settings = fs.readFileSync(settingsPath).toString();
+			const binPath: string = await vscode.commands.executeCommand("amiga.bin-path");
+			const compilerPath = path.join(binPath, "opt", "bin", "m68k-amiga-elf-gcc");
+			fs.writeFileSync(settingsPath, settings.replace('{compilerPath}', compilerPath));
 		} catch(err) {
 			void vscode.window.showErrorMessage(`Failed to init project. ${(err as Error).toString()}`);
 		}

--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "C_Cpp.default.compilerPath": "c:\\Users\\Chuck\\Documents\\Visual_Studio_Code\\amiga-debug\\bin\\opt\\bin\\m68k-amiga-elf-gcc.exe"
+    "C_Cpp.default.compilerPath": "{compilerPath}"
 }


### PR DESCRIPTION
Currently the project template includes a fixed path to a named user directory which won't be valid on another machine. This has the effect that it will fall back to the system GCC, which doesn't know about Amiga libraries etc.

I've changed this to a placeholder which gets replaced with the path of the bundled GCC binary.