### PR TITLE
Delete settings.json from template

### DIFF
--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "C_Cpp.default.compilerPath": "c:\\Users\\Chuck\\Documents\\Visual_Studio_Code\\amiga-debug\\bin\\opt\\bin\\m68k-amiga-elf-gcc.exe"
-}


### PR DESCRIPTION
This was overriding the GCC path from the configuration provider. Correct fix for #134.