### PR TITLE
CI build env tweaks

### DIFF
--- a/.github/workflows/binutils-gdb-gcc.yml
+++ b/.github/workflows/binutils-gdb-gcc.yml
@@ -25,6 +25,9 @@ jobs:
       - run: ci/gcc/download-prerequisites.sh
       - run: ci/gcc/configure-linux.sh
       - run: ci/gcc/build.sh
+        env:
+          CC:   gcc-9
+          CXX:  g++-9
       - run: ci/gcc/install.sh
       - run: ci/clean-up.sh
       - run: ci/archive-linux.sh
@@ -34,7 +37,7 @@ jobs:
           path: binutils-gdb-gcc-linux.tar
 
   macos:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
       - run: ci/install-packages-macos.sh


### PR DESCRIPTION
- Build Linux with GCC 9. This links against an older `glibc` for better compatibility. This matches the binaries I built locally that are currently in the `bin/linux` dir.
- Bump to latest Mac OS