### PR TITLE
Set default unwind values to handle ASM

### DIFF
--- a/src/backend/profile.ts
+++ b/src/backend/profile.ts
@@ -119,7 +119,7 @@ export class UnwindTable {
 			r13: -1,
 			ra: -1
 		};
-		const unwind = new Array<Unwind>(this.codeSize).fill(invalidUnwind);
+		let unwind = new Array<Unwind>(this.codeSize).fill(invalidUnwind);
 
 		const objdump = childProcess.spawnSync(this.objdumpPath, ['--dwarf=frames-interp', this.elfPath], { maxBuffer: 10 * 1024 * 1024 });
 		if (objdump.status !== 0)
@@ -217,6 +217,20 @@ export class UnwindTable {
 			else
 				line++;
 		}
+
+		// Replace remaining invalid unwinds with default values
+		const defaultUnwind: Unwind = {
+			cfaOfs: 4,
+			cfaReg: 15,
+			r13: -1,
+			ra: -4
+		};
+		unwind = unwind.map((uw) => {
+			return uw === invalidUnwind
+				? defaultUnwind
+				: uw;
+		});
+
 		this.unwind = new Int16Array(unwind.length * 3);
 		let i = 0;
 		for (const u of unwind) {


### PR DESCRIPTION
Following on from our discussion earlier, I've done a bit of testing and haven't seen any problems so far. This value will only be used for addresses which currently don't have an entry in the unwind table because no offsets were returned by `objdump`. This is likely to be assembly code.

The current default `invalidUnwind` value is skipped by WinUAE:
```c
if(unwind.cfa == ~0 || unwind.ra == ~0) break; // should not happen
```

The new default value will instead tell it to look at the top of the stack for the parent frame. If that isn't a valid code address it will stop there:
```c
while(pc >= cpu_profiler_start_addr && pc < cpu_profiler_end_addr) {
```

I've left replacing `invalidUnwind` with `defaultUnwind` to the end of the function because it's used to detect overlapping entries.