### PR TITLE
Make cpptools a recommendation, not dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -558,9 +558,6 @@
 		"vscode-debugprotocol": "^1.51.0",
 		"vscode-jsonrpc": "^6.0.0"
 	},
-	"extensionDependencies": [
-		"ms-vscode.cpptools"
-	],
 	"vsce": {
 		"dependencies": false,
 		"useYarn": false

--- a/template/.vscode/extensions.json
+++ b/template/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"BartmanAbyss.amiga-debug",
+		"ms-vscode.cpptools"
+	]
+}


### PR DESCRIPTION
I've removed `ms-vscode.cpptools` from the extension dependencies and instead added it as a recommendation in the template project. This way you get prompted to install it but it's not essential.

<img width="557" alt="image" src="https://user-images.githubusercontent.com/1519709/199119953-c85acae0-9600-4a09-8362-14f1faa5fce1.png">