### PR TITLE
Terminal PATH env case sensitive

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -340,7 +340,7 @@ class AmigaDebugExtension {
 			this.terminal = vscode.window.createTerminal({
 				name: 'Amiga',
 				env: {
-					path: [
+					PATH: [
 						"${env:PATH}",
 						this.binPath,
 						path.join(this.binPath, "opt", "bin"),


### PR DESCRIPTION
Path needs to be uppercase on Mac/Linux.