### PR TITLE
Track source from profile disassembly view

### DIFF
--- a/src/client/objdump.module.css
+++ b/src/client/objdump.module.css
@@ -18,6 +18,9 @@
   font-size: var(--vscode-editor-font-size);
   margin-bottom: 5px;
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .container {
@@ -201,4 +204,11 @@ a:focus {
 .sr_off {
   text-transform: lowercase;
   opacity: 0.5;
+}
+
+.toolbar {
+  display: flex;
+}
+.toolbar button {
+  color: var(--vscode-editor-foreground);
 }


### PR DESCRIPTION
This adds a mode in the profiler to enable following the timeline position in source files as well as disassembly. It's similar to how it works in the objdump editor when you disassemble an elf file. When this mode is enabled, scrubbing the timeline position on the flame graph will scroll through source locations in the right hand editor. This is similar to what @rjobling proposed in issue #99.

<img width="1650" alt="image" src="https://user-images.githubusercontent.com/1519709/200676806-fbf7aff0-5e64-4eca-993e-7d605d813587.png">

I've also added a toggle for the register overlay in the disassembly tab using the same UI pattern. I thought it was useful to be able to disable this when it's obscuring the disassembly content.

<img width="802" alt="image" src="https://user-images.githubusercontent.com/1519709/200677378-10013b18-22ac-4954-a740-e308fc70a143.png">