### PR TITLE
View memory for symbols in assembly

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,16 @@
 			},
 			{
 				"category": "Amiga",
+				"command": "amiga.examineMemoryVariable",
+				"title": "View Memory"
+			},
+			{
+				"category": "Amiga",
+				"command": "amiga.examineMemoryVariableIndirect",
+				"title": "View Memory (pointer)"
+			},
+			{
+				"category": "Amiga",
 				"command": "amiga.viewDisassembly",
 				"title": "View Disassembly (Function)"
 			},
@@ -438,6 +448,16 @@
 				},
 				{
 					"command": "amiga.startProfile",
+					"when": "debugType == amiga"
+				}
+			],
+			"debug/variables/context": [
+				{
+					"command": "amiga.examineMemoryVariable",
+					"when": "debugType == amiga"
+				},
+				{
+					"command": "amiga.examineMemoryVariableIndirect",
 					"when": "debugType == amiga"
 				}
 			],

--- a/src/backend/symbols.ts
+++ b/src/backend/symbols.ts
@@ -169,6 +169,7 @@ export class SymbolTable {
 		const matches = this.symbols.filter((s) =>
 			s.type === SymbolType.Normal &&
 			s.size === 0 &&
+			s.name &&
 			s.base > 0
 		);
 		return matches;
@@ -178,6 +179,8 @@ export class SymbolTable {
 		const matches = this.symbols.filter((s) =>
 			s.type === SymbolType.Normal &&
 			s.size === 0 &&
+			s.scope === SymbolScope.Local &&
+			s.name &&
 			!s.name.startsWith(".") &&
 			s.base === 0
 		);

--- a/src/backend/symbols.ts
+++ b/src/backend/symbols.ts
@@ -101,7 +101,7 @@ export class SymbolTable {
 					throw new Error(`Section ${sectionName} not found. Symbol: ${name}`);
 
 				this.symbols.push({
-					address: parseInt(match[1], 16) - section?.lma,
+					address: parseInt(match[1], 16) - (section?.lma ?? 0),
 					base: 0,
 					type,
 					scope,
@@ -162,6 +162,25 @@ export class SymbolTable {
 
 	public getGlobalVariables(): SymbolInformation[] {
 		const matches = this.symbols.filter((s) => s.type === SymbolType.Object && s.scope === SymbolScope.Global);
+		return matches;
+	}
+
+	public getSymbolVariables(): SymbolInformation[] {
+		const matches = this.symbols.filter((s) =>
+			s.type === SymbolType.Normal &&
+			s.size === 0 &&
+			s.base > 0
+		);
+		return matches;
+	}
+
+	public getConstVariables(): SymbolInformation[] {
+		const matches = this.symbols.filter((s) =>
+			s.type === SymbolType.Normal &&
+			s.size === 0 &&
+			!s.name.startsWith(".") &&
+			s.base === 0
+		);
 		return matches;
 	}
 


### PR DESCRIPTION
Due to not having structured variables in assembly code, you'll typically want to find the address of a given symbol (i.e. label) and inspect the memory at that location when debugging.

I've added a new variable scope to list symbols that don't correspond to C variables. They already exist in the symbols table and we can identify them by their type (normal) and size (0). Giving these a `memoryReference` property means you get a `View Binary Data` icon which opens the address in the `View Memory` view. 

<img width="439" alt="image" src="https://user-images.githubusercontent.com/1519709/201543746-a518b536-b809-41ec-b703-f762ef9f35e1.png">

In addition I've added a `View Memory` context menu item for this and a `View Memory (pointer)` option which adds indirection to open the memory address at that location.

<img width="353" alt="image" src="https://user-images.githubusercontent.com/1519709/201543720-78ea9625-4441-4fba-9bcb-418f764fd5b4.png">

The input dialog for the `Amiga: View Memory` command now accepts Symbol names as well as numeric addresses. You can also add a `&` prefix for indirection when using this method.

<img width="744" alt="image" src="https://user-images.githubusercontent.com/1519709/201543789-740ea4a6-9507-4f39-b77d-860d04d966a0.png">

For completeness I've also added a scope for constants defined in assembly. These look pretty similar in the symbol table but have a base of 0.

<img width="358" alt="image" src="https://user-images.githubusercontent.com/1519709/201544029-b8d4fb9e-3915-4ae9-b49a-c95af917aca0.png">