### PR TITLE
Return amiga.bin-path with forward slashes even on win32

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -157,7 +157,7 @@ class AmigaDebugExtension {
 			vscode.commands.registerCommand('amiga.profileSize', (uri: vscode.Uri) => this.profileSize(uri)),
 			vscode.commands.registerCommand('amiga.shrinkler', (uri: vscode.Uri) => this.shrinkler(uri)),
 			vscode.commands.registerCommand('amiga.disassembleElf', (uri: vscode.Uri) => this.disassembleElf(uri)),
-			vscode.commands.registerCommand('amiga.bin-path', () => path.join(this.extensionPath, 'bin', process.platform)),
+			vscode.commands.registerCommand('amiga.bin-path', () => path.join(this.extensionPath, 'bin', process.platform).split(path.sep).join('/')),
 			vscode.commands.registerCommand('amiga.initProject', this.initProject.bind(this)),
 			vscode.commands.registerCommand('amiga.terminal', this.openTerminal.bind(this)),
 			vscode.commands.registerCommand('amiga.exe2adf', (uri: vscode.Uri) => this.exe2adf(uri)),


### PR DESCRIPTION
The win32 APIs accept paths with forward slashes. Making the command `amiga.bin-path` return the path with forward slashes makes it possible and easy in our VSCode projects to have custom tasks that execute binaries from the extension via e.g. `"command": "${command:amiga.bin-path}/exe2adf"` for example. This already works on Unix platforms, but on Windows this fails because the backslashes mess up the JSON string (they are not escaped again and just added into the JSON string by VSCode verbatim, making them into escape sequences)