### PR TITLE
Linux CI binutils-gdb CI fixes

### DIFF
--- a/.github/workflows/binutils-gdb-gcc.yml
+++ b/.github/workflows/binutils-gdb-gcc.yml
@@ -15,7 +15,10 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
+    env:
+      CC:   gcc-9
+      CXX:  g++-9
     steps:
       - uses: actions/checkout@v3
       - run: ci/install-packages-linux.sh
@@ -28,9 +31,6 @@ jobs:
       - run: ci/gcc/download-prerequisites.sh
       - run: ci/gcc/configure-linux.sh
       - run: ci/gcc/build.sh
-        env:
-          CC:   gcc-9
-          CXX:  g++-9
       - run: ci/binutils-gdb/install.sh
       - run: ci/gcc/install.sh
       - run: ci/clean-up.sh

--- a/ci/binutils-gdb/configure-linux.sh
+++ b/ci/binutils-gdb/configure-linux.sh
@@ -15,7 +15,10 @@ cd build-binutils-gdb
     --disable-libcc \
     --disable-shared \
     --disable-werror \
-	--without-guile \
+    --without-guile \
+    --without-expat \
+    --without-zstd \
+    --without-lzma \
     --enable-static \
     --prefix="$PREFIX" \
     --target=m68k-amiga-elf


### PR DESCRIPTION
Improves portability of binutils/gdb binaries.

refs #181