### PR TITLE
Disassembled memory view

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
 			},
 			{
 				"category": "Amiga",
+				"command": "amiga.setDisassembledMemory",
+				"title": "Set Disassembled Memory"
+			},
+			{
+				"category": "Amiga",
 				"command": "amiga.initProject",
 				"title": "Init Project"
 			},
@@ -471,6 +476,11 @@
 		},
 		"views": {
 			"debug": [
+				{
+					"id": "amiga.disassembledMemory",
+					"name": "Disassembled Memory",
+					"when": "debugType == amiga"
+				},
 				{
 					"id": "amiga.registers",
 					"name": "CPU Registers",

--- a/src/amigaDebug.ts
+++ b/src/amigaDebug.ts
@@ -1374,6 +1374,15 @@ export class AmigaDebugSession extends LoggingDebugSession {
 			const maxDepth = await this.miDebugger.getStackDepth(args.threadId);
 			const highFrame = Math.min(maxDepth, args.startFrame + args.levels) - 1;
 			const stack = await this.miDebugger.getStack(args.threadId, args.startFrame, highFrame);
+
+			if (stack[0]) {
+				const pcDisassembly = await this.getDisassemblyForAddresses(Number(stack[0].address), 100);
+				await vscode.commands.executeCommand(
+					'amiga.setDisassembledMemory',
+					pcDisassembly
+				);
+			}
+
 			const ret: StackFrame[] = [];
 			for (const element of stack) {
 				const stackId = (args.threadId << 8 | (element.level & 0xFF)) & 0xFFFF;
@@ -2035,6 +2044,7 @@ export class AmigaDebugSession extends LoggingDebugSession {
 		let stack: Variable[];
 		try {
 			stack = await this.miDebugger.getStackVariables(threadId, frameId);
+
 			for (const variable of stack) {
 				try {
 					const varObjName = `var_${variable.name}`;

--- a/src/disassembled_memory_provider.ts
+++ b/src/disassembled_memory_provider.ts
@@ -1,0 +1,41 @@
+import * as vscode from 'vscode';
+import { DisassemblyInstruction, SourceLineWithDisassembly } from './symbols';
+
+export class DisassembledMemoryProvider implements vscode.TreeDataProvider<InstructionNode> {
+    private _onDidChangeTreeData: vscode.EventEmitter<InstructionNode | undefined> = new vscode.EventEmitter<InstructionNode | undefined>();
+    readonly onDidChangeTreeData: vscode.Event<InstructionNode | undefined> = this._onDidChangeTreeData.event;
+    private nodes?: InstructionNode[];
+
+    refresh(): void {
+        this._onDidChangeTreeData.fire(undefined);
+    }
+
+    getTreeItem(element: InstructionNode): vscode.TreeItem {
+        return element;
+    }
+
+    getChildren(element?: InstructionNode): InstructionNode[] {
+        if (!element && this.nodes) {
+            return this.nodes;
+        } else {
+            return [];
+        }
+    }
+
+    setDisassembledMemory(lines: SourceLineWithDisassembly[]): void {
+        this.nodes = [];
+        for (const dl of lines) {
+            const insts = dl.instructions.map(inst => new InstructionNode(inst));
+            this.nodes.push(...insts);
+        }
+        this.refresh();
+    }
+}
+
+export class InstructionNode extends vscode.TreeItem {
+    constructor(inst: DisassemblyInstruction) {
+        const label = `${inst.address}: ${inst.instruction}`;
+        super(label, vscode.TreeItemCollapsibleState.None);
+        this.description = inst.opcodes;
+    }
+}


### PR DESCRIPTION
This is feature I'm missing from `vscode-amiga-assembly`. It shows the next few instructions of disassembly as you're stepping through code.

<img width="531" alt="image" src="https://user-images.githubusercontent.com/1519709/204873995-898c51de-0bc1-41fb-aabb-fb8f50b84dbb.png">
