### PR TITLE
Fix `spawnAsync` input

### DIFF
--- a/src/assembly_language_provider.ts
+++ b/src/assembly_language_provider.ts
@@ -33,9 +33,13 @@ export function getEditorForDocument(doc: vscode.TextDocument): vscode.TextEdito
 	return null;
 }
 
-const spawnAsync = (cmd: string, args?: string[], options?: childProcess.SpawnOptionsWithoutStdio) =>
+const spawnAsync = (cmd: string, args?: string[], options?: childProcess.SpawnSyncOptions) =>
 	new Promise<{ stdout: Buffer; stderr: Buffer }>((res, rej) => {
 		const proc = childProcess.spawn(cmd, args, options);
+		if (options.input) {
+			proc.stdin.write(options.input);
+			proc.stdin.end();
+		}
 		const stdout = [];
 		const stderr = [];
 		proc.stdout.on('data', (data) => stdout.push(data));


### PR DESCRIPTION
Input text isn't automatically passed to stdin like `spawnSync`.