### PR TITLE
Tooltip improvements

### DIFF
--- a/src/assembly_language_provider.ts
+++ b/src/assembly_language_provider.ts
@@ -6,7 +6,7 @@ import * as os from 'os';
 import { Disassemble } from './backend/profile';
 import { GetCpuDoc, GetCpuInsns, GetCpuName, GetCustomRegDocByName } from './client/docs';
 import { decodeInstruction, instructionToString } from 'm68kdecode';
-import { instructionTimings, Timing } from './m68ktimings';
+import { formatTimingTable, instructionTimings, Timing } from './m68ktimings';
 
 enum TokenTypes {
 	function,
@@ -295,20 +295,7 @@ export class SourceContext {
 							this.cycles.set(lineNum, cycleText + "T");
 
 							let detail = "```m68k\n" + instructionToString(inst.instruction) + "\n```\n---\n";
-							if (timings.labels.length) {
-								detail += "| | Clock | Read | Write |\n";
-								detail += "|-|:-----:|:----:|:-----:|\n";
-								for (let i = 0; i < timings.labels.length; i++) {
-									const label = timings.labels[i];
-									const [c, r, w] = timings.values[i];
-									detail += `|**${label}**| ${c} | ${r} | ${w} |\n`;
-								}
-							} else {
-								const [c, r, w] = timings.values[0];
-								detail += "| Clock | Read | Write |\n";
-								detail += "|:-----:|:----:|:-----:|\n";
-								detail += `| ${c} | ${r} | ${w} |\n`;
-							}
+							detail += formatTimingTable(timings);
 							detail += `---\n${bytes.length} bytes`;
 							this.hoverText.set(lineNum, detail);
 						}

--- a/src/client/debugger/copper.tsx
+++ b/src/client/debugger/copper.tsx
@@ -2,7 +2,6 @@ import { Component, FunctionComponent, JSX } from 'preact';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import '../styles.css';
 import styles from './copper.module.css';
-import Markdown from 'markdown-to-jsx';
 
 import { IProfileModel } from '../model';
 declare const MODELS: IProfileModel[];
@@ -18,6 +17,7 @@ import { VirtualList } from '../virtual_list';
 import { useCssVariables } from '../useCssVariables';
 import { Find, FindCallback } from '../find';
 import Highlighter from 'react-highlight-words';
+import { StyledMarkdown } from '../styledMarkdown';
 class VirtualListCopper extends VirtualList<Copper> {}
 
 export const CopperView: FunctionComponent<{
@@ -177,7 +177,7 @@ export const CopperView: FunctionComponent<{
 		{hovered.markdown !== '' && (createPortal(
 			<div class={styles.tooltip_parent} style={{justifyContent: hovered.justify, left: hovered.x, top: hovered.y }}>
 				<div ref={tooltipRef} class={styles.tooltip}>
-					<Markdown>{hovered.markdown}</Markdown>
+					<StyledMarkdown>{hovered.markdown}</StyledMarkdown>
 				</div>
 			</div>, document.body))}
 	</>;

--- a/src/client/debugger/customregs.tsx
+++ b/src/client/debugger/customregs.tsx
@@ -12,9 +12,9 @@ import { CustomReadWrite, CustomSpecial, FormatCustomRegData, Custom } from '../
 import { GetCustomRegsAfterDma, SymbolizeAddress, GetPrevCustomRegWriteTime, GetNextCustomRegWriteTime, CpuCyclesToDmaCycles, DmaCyclesToCpuCycles } from '../dma';
 import { GetCustomRegDoc } from '../docs';
 import { createPortal } from 'preact/compat';
-import Markdown from 'markdown-to-jsx';
 import { useWheelHack } from '../useWheelHack';
 import { Scrollable } from '../scrollable';
+import { StyledMarkdown } from '../styledMarkdown';
 
 export const CustomRegsView: FunctionComponent<{
 	frame: number;
@@ -118,7 +118,7 @@ export const CustomRegsView: FunctionComponent<{
 		{hovered.markdown !== '' && (createPortal(
 			<div class={styles.tooltip_parent} style={{justifyContent: hovered.justify, left: hovered.x, top: hovered.y }}>
 				<div ref={tooltipRef} class={styles.tooltip}>
-					<Markdown>{hovered.markdown}</Markdown>
+					<StyledMarkdown>{hovered.markdown}</StyledMarkdown>
 				</div>
 			</div>, document.body))}
 	</>;

--- a/src/client/objdump.module.css
+++ b/src/client/objdump.module.css
@@ -84,6 +84,7 @@ svg .jumpduration {
 
 .dim2 {
   opacity: 0.6;
+  cursor: help;
 }
 
 .file {
@@ -169,13 +170,22 @@ a:focus {
 .tooltip {
 	vertical-align: bottom;
 	max-height: 250px;
-	width: 500px;
+	width: 550px;
 	box-sizing: border-box;
 	box-shadow: 0 .25em .5em 0 black;
 	padding: 5px;
 	background: var(--vscode-editorWidget-background);
 	border: 1px solid var(--vscode-editorWidget-border);
 	overflow-y: auto;
+}
+
+.timing_tooltip {
+  border: none;
+  padding: 0;
+  width: auto;
+}
+.timing_tooltip table {
+  margin: 0;
 }
 
 /* registers */

--- a/src/client/styledMarkdown.module.css
+++ b/src/client/styledMarkdown.module.css
@@ -1,0 +1,31 @@
+.container h1 {
+  font-size: 1.5em;
+  margin: 0 0 0.5em;
+}
+.container h2 {
+  font-size: 1em;
+  margin: 0.5em 0 0;
+}
+.container h3 {
+  font-size: 1em;
+  margin: 0.3em 0 0;
+}
+.container p {
+  margin: 0 0 0.5em;
+}
+.container table {
+  margin: 0.8em 0;
+  border-collapse: collapse;
+}
+.container th {
+  text-align: left;
+  white-space: nowrap;
+}
+.container tbody tr:nth-child(odd) {
+  background-color: var(--vscode-tree-tableOddRowsBackground);
+}
+.container td,
+.container th {
+  padding: 2px;
+  border: 1px solid var(--vscode-tree-tableColumnsBorder);
+}

--- a/src/client/styledMarkdown.tsx
+++ b/src/client/styledMarkdown.tsx
@@ -1,0 +1,9 @@
+import { FunctionComponent } from 'preact';
+import Markdown from 'markdown-to-jsx';
+import styles from './styledMarkdown.module.css';
+
+export const StyledMarkdown: FunctionComponent<{ children: string }> = ({ children }) => (
+	<div class={styles.container}>
+		<Markdown>{children}</Markdown>
+	</div>
+);

--- a/src/m68ktimings.ts
+++ b/src/m68ktimings.ts
@@ -866,3 +866,22 @@ export const lookupTimes: Record<string, [Timing, Timing]> = {
 	// Immediate:
 	["IMM"]:      [[4, 1, 0],  [8, 2, 0]],
 };
+
+export function formatTimingTable(timings: InstructionTiming): string {
+	let markdown = "";
+	if (timings.labels.length) {
+		markdown += "| | Clock | Read | Write |\n";
+		markdown += "|-|:-----:|:----:|:-----:|\n";
+		for (let i = 0; i < timings.labels.length; i++) {
+			const label = timings.labels[i];
+			const [c, r, w] = timings.values[i];
+			markdown += `|**${label}**| ${c} | ${r} | ${w} |\n`;
+		}
+	} else {
+		const [c, r, w] = timings.values[0];
+		markdown += "| Clock | Read | Write |\n";
+		markdown += "|:-----:|:----:|:-----:|\n";
+		markdown += `| ${c} | ${r} | ${w} |\n`;
+	}
+	return markdown;
+}


### PR DESCRIPTION
## Add CSS styles to markdown content

To improve the appearance of tooltips in the profiler, I've created a `StyledMarkdown` component which adds some basic CSS to give better, more compact defaults for font sizes, spacing and tables inside markdown blocks.

<img width="758" alt="image" src="https://user-images.githubusercontent.com/1519709/205167959-fed2f557-dd6e-4051-b42c-4737616acc9f.png">
<img width="737" alt="image" src="https://user-images.githubusercontent.com/1519709/205168212-abf50572-836d-4deb-b59e-76098b84133f.png">

## Add tooltip for instruction timings in disassembly

This replicates the hover view from the assembly editor in the disassembly view.

<img width="279" alt="image" src="https://user-images.githubusercontent.com/1519709/205168376-d7d8d448-963c-44e0-8183-3000b0170be0.png">