### PR TITLE
Increase GDB remote debugger timeout to 10 secs

### DIFF
--- a/src/amigaDebug.ts
+++ b/src/amigaDebug.ts
@@ -162,7 +162,7 @@ export class AmigaDebugSession extends LoggingDebugSession {
 		const dh0Path = path.join(binPath, "..", "dh0");
 
 		const gdbPath = path.join(binPath, "opt/bin/m68k-amiga-elf-gdb");
-		const gdbArgs = ['-q', '--interpreter=mi2'];
+		const gdbArgs = ['-q', '--interpreter=mi2', '-l', '10'];
 
 		const parseCfg = (str: string) => {
 			const out = new Map<string, string>();


### PR DESCRIPTION
This avoids filling up the network buffer by retrying commands multiple times as the remote program is starting.

Refs #193