### PR TITLE
Emulator config improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -363,6 +363,20 @@
 									"1M",
 									"1.8M"
 								]
+							},
+							"ntsc": {
+								"type": "boolean",
+								"description": "NTSC mode",
+								"default": false
+							},
+							"emuargs": {
+								"type": "array",
+								"items": {
+									"type": "string",
+									"title": "argument"
+								},
+								"description": "Addtional CLI arguments for emulator",
+								"default": []
 							}
 						}
 					}


### PR DESCRIPTION
- Adds `ntsc` option
- Passes FS-UAE options as args. It doesn't really make sense to generate a config file because unlike WinUAE, FS-UAE doesn't have a UI to edit settings at runtime, so this never gets updated.
- Adds `emuargs` option to pass additional CLI args to the emulator. Short of mirroring every available FS-UAE option in the debug launch request schema, this is really the only good way to have full control over options. You could use this to pass in custom options or the location of an externally created config file.