### PR TITLE
Toggle cycle counts

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,11 @@
 				"category": "Amiga",
 				"command": "amiga.exe2adf",
 				"title": "Amiga: Convert EXE to ADF"
+			},
+			{
+				"category": "Amiga",
+				"command": "amiga.toggleCounts",
+				"title": "Toggle Cycle Counts"
 			}
 		],
 		"languages": [

--- a/src/assembly_language_provider.ts
+++ b/src/assembly_language_provider.ts
@@ -25,14 +25,6 @@ function split_with_offset(str: string, re: RegExp) {
 	return results;
 }
 
-export function getEditorForDocument(doc: vscode.TextDocument): vscode.TextEditor {
-	for(const textEditor of vscode.window.visibleTextEditors) {
-		if(textEditor.document === doc)
-			return textEditor;
-	}
-	return null;
-}
-
 const spawnAsync = (cmd: string, args?: string[], options?: childProcess.SpawnSyncOptions) =>
 	new Promise<{ stdout: Buffer; stderr: Buffer }>((res, rej) => {
 		const proc = childProcess.spawn(cmd, args, options);
@@ -69,11 +61,8 @@ export class SourceContext {
 	constructor(public fileName: string, private diagnosticCollection: vscode.DiagnosticCollection) {
 	}
 
-	public setText(text: string) {
+	public async parse(text: string) {
 		this.text = text;
-	}
-
-	public async parse() {
 		const date = new Date();
 		const dateString = date.getFullYear().toString() + "." + (date.getMonth()+1).toString().padStart(2, '0') + "." + date.getDate().toString().padStart(2, '0') + "-" +
 			date.getHours().toString().padStart(2, '0') + "." + date.getMinutes().toString().padStart(2, '0') + "." + date.getSeconds().toString().padStart(2, '0');
@@ -312,56 +301,6 @@ export class SourceContext {
 		this.tokens = this.getTokens();
 	}
 
-	// theoretical 68000 cycle decorations
-	private static decoration = vscode.window.createTextEditorDecorationType({
-		before: {
-			textDecoration: 'none; white-space: pre; border-radius: 6px; padding: 0 10px 0 10px; position: absolute; line-height: 1rem;',
-			backgroundColor: new vscode.ThemeColor("badge.background"),
-			color: new vscode.ThemeColor("badge.foreground"),
-			margin: '2px 10px 2px 0',
-		}
-	});
-	private static decorationEmpty = vscode.window.createTextEditorDecorationType({
-		before: {
-			textDecoration: 'none; white-space: pre; padding: 0 10px 0 10px',
-			margin: '0 10px 0 0',
-			contentText: '        '
-		}
-	});
-
-	public setDecorations(textEditor: vscode.TextEditor) {
-		if(textEditor === null)
-			return;
-
-		const optionsArray: vscode.DecorationOptions[] = [];
-		for(let line = 0; line < textEditor.document.lineCount; line++) {
-			const cyclesStr = this.cycles.get(line + 1);
-			const range = new vscode.Range(new vscode.Position(line, 0), new vscode.Position(line, 0));
-			if(cyclesStr !== undefined) {
-				optionsArray.push({
-					range,
-					renderOptions: {
-						before: {
-							contentText: cyclesStr.padStart(8, ' ')
-						}
-					}
-				});
-			}
-		}
-		textEditor.setDecorations(SourceContext.decoration, optionsArray);
-	}
-
-	public setEmptyDecorations(textEditor: vscode.TextEditor) {
-		if(textEditor === null)
-			return;
-		const emptyRanges: vscode.Range[] = [];
-		for(let line = 0; line < textEditor.document.lineCount; line++) {
-			const range = new vscode.Range(new vscode.Position(line, 0), new vscode.Position(line, 0));
-			emptyRanges.push(range);
-		}
-		textEditor.setDecorations(SourceContext.decorationEmpty, emptyRanges);
-	}
-
 	private getTokens(): Token[] {
 		const tokens: Token[] = [];
 
@@ -379,58 +318,172 @@ export class SourceContext {
 	}
 }
 
+export class Decorator implements vscode.Disposable {
+	private cycles = new Map<number, string>();
+	private visible = true;
+	private subscriptions: vscode.Disposable[];
 
-export class AmigaAssemblyDocumentMananger {
-	private sourceContexts = new Map<string, SourceContext>();
-	public diagnosticCollection = vscode.languages.createDiagnosticCollection("amiga-assembly");
+	// theoretical 68000 cycle decorations
+	private static decoration = vscode.window.createTextEditorDecorationType({
+		before: {
+			textDecoration: 'none; white-space: pre; border-radius: 6px; padding: 0 10px 0 10px; position: absolute; line-height: 1rem;',
+			backgroundColor: new vscode.ThemeColor("badge.background"),
+			color: new vscode.ThemeColor("badge.foreground"),
+			margin: '2px 10px 2px 0',
+		}
+	});
+	private static decorationEmpty = vscode.window.createTextEditorDecorationType({
+		before: {
+			textDecoration: 'none; white-space: pre; padding: 0 10px 0 10px',
+			margin: '0 10px 0 0',
+			contentText: '        '
+		}
+	});
 
-	constructor(extensionPath: string, selector: vscode.DocumentSelector) {
-		SourceContext.extensionPath = extensionPath;
+	constructor (private document: vscode.TextDocument) {
+		this.subscriptions = [
+			vscode.workspace.onDidChangeTextDocument((event) => {
+				if (this.visible && event.document === this.document) {
+					// Immediately set placeholder decorations for each line to create space and avoid delay / jumping.
+					// Once the cycles have been counted, setCycles will be called to populate the values.
+					this.setEmptyDecorations();
+				}
+			}),
+			vscode.window.onDidChangeVisibleTextEditors((editors) => {
+				if (this.visible && editors.some((e) => e.document === this.document)) {
+					this.show();
+				}
+			}),
+		];
+		this.show();
+	}
 
-		const changeTimers = new Map<string, NodeJS.Timeout>(); // Keyed by file name.
+	public dispose() {
+		this.subscriptions.forEach((subscription) => {
+			subscription.dispose();
+		});
+	}
 
-		// parse documents that are already open when extension is activated
-		for(const document of vscode.workspace.textDocuments) {
-			if (vscode.languages.match(selector, document)) {
-				console.log("initial parse " + document.fileName);
-				this.getSourceContext(document.fileName).setText(document.getText());
-				this.getSourceContext(document.fileName).setEmptyDecorations(getEditorForDocument(document));
-				void this.getSourceContext(document.fileName).parse().then(() => {
-					this.getSourceContext(document.fileName).setDecorations(getEditorForDocument(document));
+	public setCycles(cycles: Map<number, string>) {
+		this.cycles = cycles;
+		if (this.visible) {
+			this.setDecorations();
+		}
+	}
+
+	public toggle(): void {
+		return this.visible ? this.hide() : this.show();
+	}
+
+	public hide(): void {
+		this.visible = false;
+		this.getTextEditors().forEach((editor) => {
+			editor.setDecorations(Decorator.decorationEmpty, []);
+			editor.setDecorations(Decorator.decoration, []);
+		});
+	}
+
+	public show(): void {
+		this.visible = true;
+		this.setEmptyDecorations();
+		this.setDecorations();
+	}
+
+	private setEmptyDecorations() {
+		const emptyRanges: vscode.Range[] = [];
+		for(let line = 0; line < this.document.lineCount; line++) {
+			const range = new vscode.Range(new vscode.Position(line, 0), new vscode.Position(line, 0));
+			emptyRanges.push(range);
+		}
+		this.getTextEditors().forEach((editor) => {
+			editor.setDecorations(Decorator.decorationEmpty, emptyRanges);
+		});
+	}
+
+	private setDecorations() {
+		const optionsArray: vscode.DecorationOptions[] = [];
+		for(let line = 0; line < this.document.lineCount; line++) {
+			const cyclesStr = this.cycles.get(line + 1);
+			const range = new vscode.Range(new vscode.Position(line, 0), new vscode.Position(line, 0));
+			if(cyclesStr !== undefined) {
+				optionsArray.push({
+					range,
+					renderOptions: {
+						before: {
+							contentText: cyclesStr.padStart(8, ' ')
+						}
+					}
 				});
 			}
 		}
+		this.getTextEditors().forEach((editor) => {
+			editor.setDecorations(Decorator.decoration, optionsArray);
+		});
+	}
+
+	private getTextEditors(): vscode.TextEditor[] {
+		return vscode.window.visibleTextEditors.filter((e) => e.document === this.document);
+	}
+}
+
+
+export class AmigaAssemblyDocumentMananger implements vscode.Disposable {
+	private sourceContexts = new Map<string, SourceContext>();
+	private decorators = new Map<vscode.TextDocument,Decorator>();
+	private subscriptions: vscode.Disposable[] = [];
+	private changeTimers = new Map<string, NodeJS.Timeout>(); // Keyed by file name.
+	public diagnosticCollection = vscode.languages.createDiagnosticCollection("amiga-assembly");
+
+	constructor(extensionPath: string, private selector: vscode.DocumentSelector) {
+		SourceContext.extensionPath = extensionPath;
+
+		vscode.workspace.textDocuments.map((document) => {
+			this.decorators.set(document, new Decorator(document));
+			// parse documents that are already open when extension is activated
+			this.processDocument(document);
+		});
 
 		// parse documents when they are opened
-		vscode.workspace.onDidOpenTextDocument((document: vscode.TextDocument) => {
-			if (vscode.languages.match(selector, document)) {
-				console.log("openTextDocument: initial parse " + document.fileName);
-				this.getSourceContext(document.fileName).setEmptyDecorations(getEditorForDocument(document));
-				this.getSourceContext(document.fileName).setText(document.getText());
-				void this.getSourceContext(document.fileName).parse().then(() => {
-					this.getSourceContext(document.fileName).setDecorations(getEditorForDocument(document));
-				});
-			}
-		});
+		this.subscriptions.push(
+			vscode.workspace.onDidOpenTextDocument((document) => {
+				this.decorators.set(document, new Decorator(document));
+				this.processDocument(document);
+			})
+		);
 
 		// reparse documents in the background when they are modified
-		vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
-			if (vscode.languages.match(selector, event.document)) {
-				const fileName = event.document.fileName;
-				this.getSourceContext(event.document.fileName).setEmptyDecorations(getEditorForDocument(event.document));
-				this.getSourceContext(event.document.fileName).setText(event.document.getText());
-				if (changeTimers.has(fileName)) {
-					clearTimeout(changeTimers.get(fileName));
+		this.subscriptions.push(
+			vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
+				if (vscode.languages.match(selector, event.document)) {
+					const fileName = event.document.fileName;
+					if (this.changeTimers.has(fileName)) {
+						clearTimeout(this.changeTimers.get(fileName));
+					}
+					this.changeTimers.set(fileName, setTimeout(() => {
+						this.changeTimers.delete(fileName);
+						console.log("reparse " + event.document.fileName);
+						this.processDocument(event.document);
+					}, 300));
 				}
-				changeTimers.set(fileName, setTimeout(() => {
-					changeTimers.delete(fileName);
-					console.log("reparse " + event.document.fileName);
-					void this.getSourceContext(event.document.fileName).parse().then(() => {
-						this.getSourceContext(event.document.fileName).setDecorations(getEditorForDocument(event.document));
-					});
-				}, 300));
-			}
-		});
+			})
+		);
+
+		// clean up on document close
+		this.subscriptions.push(
+			vscode.workspace.onDidCloseTextDocument((document) => {
+				this.decorators.delete(document);
+				this.sourceContexts.delete(document.fileName);
+			})
+		);
+	}
+
+	private processDocument(document: vscode.TextDocument) {
+		if (vscode.languages.match(this.selector, document)) {
+			const ctx = this.getSourceContext(document.fileName);
+			void ctx.parse(document.getText()).then(() => {
+				this.decorators.get(document).setCycles(ctx.cycles);
+			});
+		}
 	}
 
 	public getSourceContext(fileName: string): SourceContext {
@@ -442,8 +495,17 @@ export class AmigaAssemblyDocumentMananger {
 		return context;
 	}
 
+	public toggleCounts() {
+		const decorator = this.decorators.get(vscode.window.activeTextEditor.document);
+		if (decorator) {
+			decorator.toggle();
+		}
+	}
+
 	public dispose() {
 		this.diagnosticCollection.dispose();
+		this.decorators.forEach((decorator) => decorator.dispose());
+		this.changeTimers.forEach(clearTimeout);
 	}
 }
 

--- a/src/counts_codelens_provider.ts
+++ b/src/counts_codelens_provider.ts
@@ -1,0 +1,15 @@
+import { CodeLens, CodeLensProvider, Range, Command } from 'vscode';
+
+export class CountCodeLensProvider implements CodeLensProvider {
+	provideCodeLenses(): CodeLens[] {
+		const topOfDocument = new Range(1, 0, 0, 0);
+
+		const c: Command = {
+			command: "amiga.toggleCounts",
+			title: "Toggle theoretical counts",
+		};
+		const codeLens = new CodeLens(topOfDocument, c);
+
+		return [codeLens];
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ import { CancellationToken } from 'vscode-jsonrpc';
 import { DisassemblyContentProvider } from './disassembly_content_provider';
 import { ProfileCodeLensProvider } from './profile_codelens_provider';
 import { ProfileEditorProvider } from './profile_editor_provider';
-import { AmigaAssemblyDocumentMananger, AmigaAssemblyLanguageProvider, getEditorForDocument } from './assembly_language_provider';
+import { AmigaAssemblyDocumentMananger, AmigaAssemblyLanguageProvider } from './assembly_language_provider';
 import { BaseNode as RBaseNode, CustomRegisterTreeProvider, FieldNode, RegisterTreeProvider, TreeNode as RTreeNode } from './registers';
 import { NumberFormat, SourceLineWithDisassembly, SymbolInformation, SymbolScope } from './symbols';
 import { SymbolTable } from './backend/symbols';
@@ -25,6 +25,7 @@ import { SavestateEditorProvider } from './savestate_editor_provider';
 import { hexFormat } from './utils';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { DisassembledMemoryProvider } from './disassembled_memory_provider';
+import { CountCodeLensProvider } from './counts_codelens_provider';
 
 /*
  * Set the following compile time flag to true if the
@@ -131,6 +132,7 @@ class AmigaDebugExtension {
 		this.outputChannel = vscode.window.createOutputChannel('Amiga');
 
 		const lenses = new ProfileCodeLensProvider();
+		const countsLens = new CountCodeLensProvider();
 		const assemblyLanguagesInt: vscode.DocumentFilter[] = [ { language: 'amiga.assembly' } ];
 		const assemblyLanguagesExt: vscode.DocumentFilter[] = [ { language: 'm68k' } ];
 		this.assemblyLanguageSelector = [
@@ -180,6 +182,7 @@ class AmigaDebugExtension {
 			vscode.commands.registerCommand('amiga.externalResources.bltconCheatSheet', () => vscode.env.openExternal(vscode.Uri.parse('http://deadliners.net/BLTCONCheatSheet'))),
 			vscode.commands.registerCommand('amiga.externalResources.amigaHRM', () => vscode.commands.executeCommand('simpleBrowser.show', 'http://amigadev.elowar.com/read/ADCD_2.1/Hardware_Manual_guide/node0000.html')),
 			vscode.commands.registerCommand('amiga.setDisassembledMemory', (lines: SourceLineWithDisassembly[]) => this.disassembledMemoryProvider.setDisassembledMemory(lines)),
+			vscode.commands.registerCommand('amiga.toggleCounts', () => this.assemblyDocumentManager.toggleCounts()),
 
 			// window
 			vscode.window.registerTreeDataProvider('amiga.registers', this.registerProvider),
@@ -207,8 +210,11 @@ class AmigaDebugExtension {
 			vscode.languages.registerDefinitionProvider(assemblyLanguagesInt, assemblyLanguageProvider),
 			vscode.languages.registerHoverProvider(assemblyLanguagesInt, assemblyLanguageProvider),
 			vscode.languages.registerCompletionItemProvider(assemblyLanguagesInt, assemblyLanguageProvider),
+			vscode.languages.registerCodeLensProvider(assemblyLanguagesInt, countsLens),
 			// assembly language (extensions)
 			vscode.languages.registerHoverProvider(assemblyLanguagesExt, assemblyLanguageProviderExt),
+			vscode.languages.registerCodeLensProvider(assemblyLanguagesExt, countsLens),
+
 			this.assemblyDocumentManager,
 
 			// output channel
@@ -250,11 +256,6 @@ class AmigaDebugExtension {
 	}
 
 	private activeEditorChanged(editor: vscode.TextEditor) {
-		if(vscode.languages.match(this.assemblyLanguageSelector, editor?.document)) {
-			this.assemblyDocumentManager.getSourceContext(editor.document.fileName).setEmptyDecorations(getEditorForDocument(editor.document));
-			this.assemblyDocumentManager.getSourceContext(editor.document.fileName).setDecorations(getEditorForDocument(editor.document));
-			return;
-		}
 		if(editor !== undefined && vscode.debug.activeDebugSession && vscode.debug.activeDebugSession.type === 'amiga') {
 			const uri = editor.document.uri;
 			if(uri.scheme === 'file') {


### PR DESCRIPTION
- Adds ability to toggle visibility of cycle counts via command or code lens
- Refactored logic for text editor decorations to be contained within a single `Decorator` class
- Correctly handles multiple instances of the same document e.g. split view. Previously only the first visible editor for the current doc would be updated
- Event subscriptions are now disposed of correctly