### PR TITLE
debug save location cwd

### DIFF
--- a/src/amigaDebug.ts
+++ b/src/amigaDebug.ts
@@ -547,7 +547,10 @@ export class AmigaDebugSession extends LoggingDebugSession {
 		}
 
 		// launch Emulator
-		const cwd = dirname(emuPath);
+		const cwd = isWin
+			? dirname(emuPath)
+			// CWD determines location for debug_save/debug_load on FS-UAE
+			: vscode.workspace.workspaceFolders[0].uri.fsPath;
 		const env = {
 			...process.env,
 			LD_LIBRARY_PATH: ".", // Allow Linux fs-uae to find bundled .so files


### PR DESCRIPTION
Change emulator cwd so that `debug_load`/`debug_save` writes files relative to the workspace directory.

This only works for FS-UAE. CWD doesn't seem to have any effect on WinUAE, but I left it as-is just in case there are any unintended side effects that I missed.