### PR TITLE
Set `--disable-source-highlight` on binutils-gdb CI

### DIFF
--- a/ci/binutils-gdb/configure-macos.sh
+++ b/ci/binutils-gdb/configure-macos.sh
@@ -18,5 +18,6 @@ cd build-binutils-gdb
     --disable-werror \
 	--without-guile \
     --enable-static \
+	--disable-source-highlight \
     --prefix="$PREFIX" \
     --target=m68k-amiga-elf


### PR DESCRIPTION
This addresses the error which suddenly appeared.

fixes #246