### PR TITLE
template: Fix `GetVBR` for systems with caches enabled

### DIFF
--- a/template/main.c
+++ b/template/main.c
@@ -27,12 +27,16 @@ static APTR SystemIrq;
  
 struct View *ActiView;
 
+static ULONG SupervisorGetVBR(void) {
+	__asm__ __volatile__("movec.l %%vbr, %%d0 ; rte" : : : "%d0");
+	__builtin_unreachable();
+}
+
 static APTR GetVBR(void) {
 	APTR vbr = 0;
-	UWORD getvbr[] = { 0x4e7a, 0x0801, 0x4e73 }; // MOVEC.L VBR,D0 RTE
 
 	if (SysBase->AttnFlags & AFF_68010) 
-		vbr = (APTR)Supervisor((ULONG (*)())getvbr);
+		vbr = (APTR)Supervisor(SupervisorGetVBR);
 
 	return vbr;
 }


### PR DESCRIPTION
Previously, the supervisor portion of `GetVBR` would be copied to the stack, but without then clearing caches, there would be no guarantee that the instruction cache would contain this data (it's most likely dirty in the data cache and not yet committed to memory). On my setup (060 fpu+mmu), this would consistently crash.

So, let's rewrite this code as inline asm in a function, which is cleaner (no more raw data words), avoids the unnecessary copy (to initialize a local variable which isn't actually required), and avoids an unnecessary cache clear (which would also work around the issue, but in an expensive way).

Fixes #256.